### PR TITLE
Return nothing if everything has been filtered out

### DIFF
--- a/packages/awdb_forecasts/awdb_forecasts/lib/forecasts.py
+++ b/packages/awdb_forecasts/awdb_forecasts/lib/forecasts.py
@@ -29,8 +29,9 @@ class ForecastResultCollection:
         """
         Given a list of station triples, fetch all associated data for them
         """
+        if not station_triplets:
+            return {}
 
-        assert station_triplets, "No station triplets provided"
         station_triplets_comma_separated = ",".join(station_triplets)
         assert element_code
         url = f"https://wcc.sc.egov.usda.gov/awdbRestApi/services/v1/forecasts?elements={element_code}&stationTriplets={station_triplets_comma_separated}"


### PR DESCRIPTION
If a user requests an item that doesnt exist, previously this would just fail and return a server error. Returning an empty {} is ok and will propagate to return an empty coverage collection. 

I think this is the best way given the following issue exists:
#36 