### PR TITLE
Remove cache step from Docker build

### DIFF
--- a/pygeoapi-deployment/Dockerfile
+++ b/pygeoapi-deployment/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update && apt-get install -y libgdal-dev git build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 # Install all dependencies
-# Use buildkit with docker to persist uv installation cache for faster builds 
 RUN uv sync --all-groups --all-packages
 
 COPY pygeoapi-deployment/ /opt/pygeoapi/pygeoapi-deployment/

--- a/pygeoapi-deployment/Dockerfile
+++ b/pygeoapi-deployment/Dockerfile
@@ -16,8 +16,7 @@ RUN apt-get update && apt-get install -y libgdal-dev git build-essential \
 
 # Install all dependencies
 # Use buildkit with docker to persist uv installation cache for faster builds 
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --all-groups --all-packages
+RUN uv sync --all-groups --all-packages
 
 COPY pygeoapi-deployment/ /opt/pygeoapi/pygeoapi-deployment/
 


### PR DESCRIPTION
GCP Cloud build hangs because Docker BuildKit is not installed. This removes the cache