### PR TITLE
Better OAF testing that generalizes across providers

### DIFF
--- a/packages/awdb_forecasts/awdb_forecasts/awdb_forecasts.py
+++ b/packages/awdb_forecasts/awdb_forecasts/awdb_forecasts.py
@@ -39,7 +39,7 @@ class AwdbForecastsProvider(BaseProvider, OAFProviderProtocol):
         bbox: list = [],
         datetime_: Optional[str] = None,
         resulttype: Optional[Literal["hits", "results"]] = "results",
-        # select only features that contains all the `select_properties` values
+        # Filter out any properties in a given feature not in this list
         select_properties: Optional[
             list[str]
         ] = None,  # query this with ?properties in the actual url
@@ -55,9 +55,7 @@ class AwdbForecastsProvider(BaseProvider, OAFProviderProtocol):
         **kwargs,
     ) -> GeojsonFeatureCollectionDict | GeojsonFeatureDict:
         # items/ returns all features, locations/ returns only features with timeseries, and thus forecasts
-        collection = ForecastLocationCollection(
-            select_properties, only_stations_with_forecasts=False
-        )
+        collection = ForecastLocationCollection(only_stations_with_forecasts=False)
         if itemId:
             collection.drop_all_locations_but_id(itemId)
         if bbox:
@@ -66,10 +64,11 @@ class AwdbForecastsProvider(BaseProvider, OAFProviderProtocol):
         if datetime_:
             collection.select_date_range(datetime_)
 
-        if limit:
-            collection.drop_after_limit(limit)
         if offset:
             collection.drop_before_offset(offset)
+
+        if limit:
+            collection.drop_after_limit(limit)
 
         if resulttype == "hits":
             return {

--- a/packages/awdb_forecasts/awdb_forecasts/lib/forecast_locations.py
+++ b/packages/awdb_forecasts/awdb_forecasts/lib/forecast_locations.py
@@ -9,7 +9,7 @@ from com.helpers import EDRFieldsMapping, await_
 from com.protocol import LocationCollectionProtocolWithEDR
 from rise.lib.covjson.types import CoverageCollectionDict
 from typing import Optional, cast
-
+from pygeoapi.provider.base import ProviderQueryError
 
 type longitudeAndLatitude = tuple[float, float]
 
@@ -26,6 +26,9 @@ class ForecastLocationCollection(LocationCollection, LocationCollectionProtocolW
             url += f"&elements={','.join(select_properties)}"
         result = await_(self.cache.get_or_fetch_json(url))
         locations: list[StationDTO] = []
+
+        if "error" in result:
+            raise ProviderQueryError(result["error"])
 
         for res in result:
             if only_stations_with_forecasts:

--- a/packages/com/src/com/oaf_test.py
+++ b/packages/com/src/com/oaf_test.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 from awdb_forecasts.awdb_forecasts import AwdbForecastsProvider
 from com.protocol import OAFProviderProtocol
 from noaa_rfc.noaa_rfc import NOAARFCProvider

--- a/packages/com/src/com/oaf_test.py
+++ b/packages/com/src/com/oaf_test.py
@@ -1,0 +1,127 @@
+from awdb_forecasts.awdb_forecasts import AwdbForecastsProvider
+from com.protocol import OAFProviderProtocol
+from noaa_rfc.noaa_rfc import NOAARFCProvider
+from rise.rise import RiseProvider
+from snotel.snotel import SnotelProvider
+from usace.usace import USACEProvider
+import pytest
+
+provider_def = {
+    "name": "test",
+    "type": "feature",
+    "data": "remote",
+}
+
+
+@pytest.mark.parametrize(
+    "provider_class",
+    [
+        USACEProvider,
+        RiseProvider,
+        AwdbForecastsProvider,
+        SnotelProvider,
+        NOAARFCProvider,
+    ],
+)
+def test_oaf_provider(provider_class):
+    provider: OAFProviderProtocol = provider_class(provider_def=provider_def)
+
+    allItems = provider.items()
+    assert len(allItems) > 0
+
+    def test_single_item():
+        assert "features" in allItems
+        firstItem = allItems["features"][0]
+        singleItem = provider.items(itemId=str(firstItem["id"]), skip_geometry=True)
+        assert "features" not in singleItem
+        assert not singleItem["geometry"]
+
+    test_single_item()
+
+    def test_offset_and_limit():
+        offsetAndLimit = provider.items(offset=1, limit=1)
+        assert "features" in offsetAndLimit
+        assert len(offsetAndLimit["features"]) == 1
+        assert "features" in allItems
+        assert offsetAndLimit["features"][0] == allItems["features"][1]
+
+    test_offset_and_limit()
+
+    def test_hit_count():
+        hitCount = provider.items(resulttype="hits")
+        assert "numberMatched" in hitCount
+        assert "features" in allItems
+        assert hitCount["numberMatched"] == len(allItems["features"])
+
+    test_hit_count()
+
+    def test_filter_out_features_by_properties():
+        fields = provider.get_fields()
+        assert len(fields) > 0
+        # with pytest.raises(ProviderQueryError):
+        #     provider.items(properties=[("DUMMY", "DUMMY")])
+
+        firstProperty = list(fields.keys())[0]
+        dummyVal: str | int | float
+        # generate a dummy value that is the same type as the first property
+        # so we can filter without getting a type error
+        match type := fields[firstProperty]["type"]:
+            case "string":
+                dummyVal = "____DUMMY"
+            case "number":
+                dummyVal = -99999.9999
+            case "integer":
+                dummyVal = -99999
+            case _:
+                raise AssertionError(f"Unknown field type {type}")
+
+        out = provider.items(properties=[(firstProperty, str(dummyVal))])
+        assert "features" in out
+        # if we filter by a dummy value, we expect no features to be returned
+        assert len(out["features"]) == 0
+
+    test_filter_out_features_by_properties()
+
+    def test_sort_by_properties():
+        fields = provider.get_fields()
+        assert len(fields) > 0
+        firstProperty = list(fields.keys())[0]
+        out = provider.items(sortby=[{"property": firstProperty, "order": "+"}])
+        assert "features" in out
+        assert len(out["features"]) >= 3, (
+            "There were less than 3 features returned so we can't test sorting"
+        )
+        assert (
+            out["features"][0]["properties"][firstProperty]
+            <= out["features"][1]["properties"][firstProperty]
+            <= out["features"][2]["properties"][firstProperty]
+        )
+        out = provider.items(sortby=[{"property": firstProperty, "order": "-"}])
+        assert "features" in out
+        assert len(out["features"]) >= 3, (
+            "There were less than 3 features returned so we can't test sorting"
+        )
+        assert (
+            out["features"][0]["properties"][firstProperty]
+            >= out["features"][1]["properties"][firstProperty]
+            >= out["features"][2]["properties"][firstProperty]
+        )
+
+    test_sort_by_properties()
+
+    def test_filter_by_bounding_box():
+        # We can test it works but we can't test it returns the right features
+        # without a lot of extra work in the test since some features can have no geometry
+        out = provider.items(bbox=[-180, -90, 180, 90])
+        assert "features" in out
+
+    test_filter_by_bounding_box()
+
+    def test_filter_out_extra_parameters():
+        out = provider.items(
+            select_properties=["DUMMY"],
+        )
+        assert "features" in out
+        assert out["features"][0]["properties"] == {}
+
+    test_filter_out_extra_parameters()

--- a/packages/noaa_rfc/src/noaa_rfc/lib/forecast.py
+++ b/packages/noaa_rfc/src/noaa_rfc/lib/forecast.py
@@ -146,7 +146,7 @@ def get_water_year() -> str:
 
 
 class ForecastCollection(LocationCollectionProtocol):
-    forecasts: list[ForecastDataSingle] = []
+    locations: list[ForecastDataSingle] = []
 
     def _get_data(self):
         water_year = get_water_year()
@@ -211,11 +211,11 @@ class ForecastCollection(LocationCollectionProtocol):
                 item = {k: v[i] if v else None for k, v in dumped.items()}
                 pivoted_forecasts.append(ForecastDataSingle.model_validate(item))
 
-        self.forecasts = pivoted_forecasts
+        self.locations = pivoted_forecasts
 
     def drop_all_locations_but_id(self, location_id: str):
-        self.forecasts = [
-            forecast for forecast in self.forecasts if forecast.espid == location_id
+        self.locations = [
+            forecast for forecast in self.locations if forecast.espid == location_id
         ]
 
     def _filter_by_geometry(
@@ -233,7 +233,7 @@ class ForecastCollection(LocationCollectionProtocol):
         sortby: Optional[list[SortDict]] = None,
     ) -> GeojsonFeatureCollectionDict | GeojsonFeatureDict:
         features: list[Feature] = []
-        for forecast in self.forecasts:
+        for forecast in self.locations:
             forecast.extend_with_metadata()
 
             serialized_feature = Feature(
@@ -263,12 +263,14 @@ class ForecastCollection(LocationCollectionProtocol):
             features.append(serialized_feature)
 
         if itemsIDSingleFeature:
-            return cast(GeojsonFeatureDict, features[0].model_dump())
+            return cast(GeojsonFeatureDict, features[0].model_dump(exclude_unset=True))
 
         if sortby:
             sort_by_properties_in_place(features, sortby)
 
         return cast(
             GeojsonFeatureCollectionDict,
-            FeatureCollection(type="FeatureCollection", features=features).model_dump(),
+            FeatureCollection(type="FeatureCollection", features=features).model_dump(
+                exclude_unset=True
+            ),
         )

--- a/packages/noaa_rfc/src/noaa_rfc/lib/forecast_test.py
+++ b/packages/noaa_rfc/src/noaa_rfc/lib/forecast_test.py
@@ -10,4 +10,4 @@ def test_fetch_locations():
 
     collection.drop_all_locations_but_id("AFPU1")
 
-    assert len(collection.forecasts) == 3
+    assert len(collection.locations) == 3

--- a/packages/noaa_rfc/src/noaa_rfc/noaa_rfc.py
+++ b/packages/noaa_rfc/src/noaa_rfc/noaa_rfc.py
@@ -62,7 +62,7 @@ class NOAARFCProvider(BaseProvider, OAFProviderProtocol):
             return {
                 "type": "FeatureCollection",
                 "features": [],
-                "numberMatched": len(collection.forecasts),
+                "numberMatched": len(collection.locations),
             }
 
         if offset:
@@ -75,6 +75,7 @@ class NOAARFCProvider(BaseProvider, OAFProviderProtocol):
             itemsIDSingleFeature=itemId is not None,
             skip_geometry=skip_geometry,
             sortby=sortby,
+            fields_mapping=self.get_fields(),
             properties=properties,
             select_properties=select_properties,
         )

--- a/packages/snotel/snotel/snotel.py
+++ b/packages/snotel/snotel/snotel.py
@@ -63,10 +63,11 @@ class SnotelProvider(BaseProvider, OAFProviderProtocol):
         if datetime_:
             collection.select_date_range(datetime_)
 
-        if limit:
-            collection.drop_after_limit(limit)
         if offset:
             collection.drop_before_offset(offset)
+
+        if limit:
+            collection.drop_after_limit(limit)
 
         if resulttype == "hits":
             return {

--- a/packages/usace/usace/lib/locations_collection.py
+++ b/packages/usace/usace/lib/locations_collection.py
@@ -63,7 +63,7 @@ class LocationCollection(LocationCollectionProtocolWithEDR):
             serialized_feature = geojson_pydantic.Feature(
                 type="Feature",
                 id=feature.id,
-                properties=feature.properties,
+                properties=feature.properties.model_dump(),
                 geometry=geojson_pydantic.Point(
                     type="Point",
                     coordinates=Position2D(
@@ -93,12 +93,12 @@ class LocationCollection(LocationCollectionProtocolWithEDR):
 
         if itemsIDSingleFeature:
             assert len(self.locations) == 1
-            return cast(GeojsonFeatureDict, self.locations[0].model_dump())
+            return cast(GeojsonFeatureDict, features_to_keep[0].model_dump())
         return cast(
             GeojsonFeatureCollectionDict,
             geojson_pydantic.FeatureCollection(
                 type="FeatureCollection", features=features_to_keep
-            ).model_dump(),
+            ).model_dump(exclude_unset=True),
         )
 
     @TRACER.start_as_current_span("geometry_filter")

--- a/packages/usace/usace/usace.py
+++ b/packages/usace/usace/usace.py
@@ -59,10 +59,10 @@ class USACEProvider(BaseProvider, OAFProviderProtocol):
             collection.drop_all_locations_but_id(itemId)
         if bbox:
             collection.drop_all_locations_outside_bounding_box(bbox)
-        if limit:
-            collection.drop_after_limit(limit)
         if offset:
             collection.drop_before_offset(offset)
+        if limit:
+            collection.drop_after_limit(limit)
         if datetime_:
             raise NotImplementedError(
                 "Datetime filters are not supported since the OAF properties do not contain any temporal data"
@@ -79,6 +79,7 @@ class USACEProvider(BaseProvider, OAFProviderProtocol):
             itemsIDSingleFeature=itemId is not None,
             skip_geometry=skip_geometry,
             select_properties=select_properties,
+            fields_mapping=self.get_fields(),
             sortby=sortby,
             properties=properties,
         )


### PR DESCRIPTION
Use a table driven test for testing OAF behavior across all providers; makes sure that all providers are behaving relatively similarly. 

More tests to come in the future. Will do a similar thing for EDR