### PR TITLE
Fix rise tests for param with no data

### DIFF
--- a/packages/com/src/com/edr_test.py
+++ b/packages/com/src/com/edr_test.py
@@ -7,6 +7,7 @@ import pytest
 from rise.rise_edr import RiseEDRProvider
 from snotel.snotel_edr import SnotelEDRProvider
 from usace.usace_edr import USACEEDRProvider
+from pygeoapi.provider.base import ProviderNoDataError
 
 provider_def = {
     "name": "test",
@@ -51,14 +52,19 @@ def test_edr_provider(provider_class):
     test_location_id()
 
     def test_select_properties():
-        selectedProvider = provider.locations(
-            select_properties=[list(fields.keys())[0]]
-        )
-        assert "features" in selectedProvider
-        # awdb forecasts contains parameters that could potentially not have
-        # data associated with them; this is since it shares the same upstream param api as snotel
-        if not isinstance(provider, AwdbForecastsEDRProvider):
-            assert len(selectedProvider["features"]) > 0
+        try:
+            selectedProvider = provider.locations(
+                select_properties=[list(fields.keys())[0]]
+            )
+            assert "features" in selectedProvider
+            # awdb forecasts contains parameters that could potentially not have
+            # data associated with them; this is since it shares the same upstream param api as snotel
+            if not isinstance(provider, AwdbForecastsEDRProvider):
+                assert len(selectedProvider["features"]) > 0
+        except ProviderNoDataError:
+            # it is possible for rise to have no data associated with a parameter
+            if not isinstance(provider, RiseEDRProvider):
+                raise
 
     test_select_properties()
 

--- a/packages/rise/rise/lib/location.py
+++ b/packages/rise/rise/lib/location.py
@@ -56,7 +56,7 @@ class LocationResponse(BaseModel):
         ]
     ] = None
     # data represents the list of locations returned
-    data: list[LocationData]
+    data: list[LocationData] = []
     included: Optional[list[LocationIncluded]] = None
 
     @classmethod

--- a/packages/rise/rise/rise_edr.py
+++ b/packages/rise/rise/rise_edr.py
@@ -7,9 +7,7 @@ from typing import ClassVar, Optional
 from com.helpers import await_
 from com.otel import otel_trace
 from com.protocols.providers import EDRProviderProtocol
-from pygeoapi.provider.base import (
-    ProviderQueryError,
-)
+from pygeoapi.provider.base import ProviderQueryError, ProviderNoDataError
 from pygeoapi.provider.base_edr import BaseEDRProvider
 from rise.lib.covjson.covjson import CovJSONBuilder
 from rise.lib.location import LocationResponse
@@ -64,6 +62,10 @@ class RiseEDRProvider(BaseEDRProvider, EDRProviderProtocol):
             raise ProviderQueryError("Can't filter by date on every location")
 
         raw_resp = self.cache.get_or_fetch_all_param_filtered_pages(select_properties)
+        if not raw_resp:
+            raise ProviderNoDataError(
+                f"No locations found with properties {select_properties}"
+            )
         response = LocationResponse.from_api_pages_with_included_catalog_items(raw_resp)
 
         if location_id:


### PR DESCRIPTION
Seems like rise might be changing some upstream stuff, since upon cache invalidation there appears to be a few params with no associated locations. 

i.e. https://data.usbr.gov/rise/api/location?order[id]=asc&include=catalogRecords.catalogItems&itemStructureId=1&parameterId%5B%5D=1721 returns no locations