### PR TITLE
Usace param mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Western Water Datahub
 
-The Wester Water Datahub (WWDH) is an implementation of the [OGC API](https://ogcapi.ogc.org/) suite of standards, enabling access to water data from various sources through a unified interface. It is designed to enhance data interoperability, accessibility, and discoverability across multiple agricultural water data platforms.
+The Wester Water Datahub (WWDH) is an implementation of the [OGC API](https://ogcapi.ogc.org/) suite of standards, enabling access to water data from various sources through a unified interface. It is designed to enhance data interoperability, accessibility, and discoverability across multiple water data platforms.
 
 This project is a collaboration between the United States Beaureu of Reclamation, the Center for Geospatial Solutions, and Wester States Water Council.
 
@@ -14,28 +14,35 @@ The interface consolidates access to multiple water data sources, offering a sta
 | NRCS/SNOTEL | Snow Water Equivalent (station, current/historical)       | Features, EDR  |
 | USGS/WMA    | Streamflow (current)                                      | Features, EDR  |
 | AWDB        | Streamflow (forecast)                                     | Features, EDR  |
+| USACE       | Reservoir Storage/Release/Level/Evap (forecast)           | Features, EDR  |
 | NOAA/QPF    | Precipitation (Raster forecast)                           | Features       |
-| NOAA/NOHRSC | Snow Water (forecast)                                     | Maps           |
+| NOAA/RFC    | Streamflow (forecast)                                     | Features       |
+| NOAA/NOHRSC | Snow Water/Depth (forecast)                               | Maps           |
 | PRISM       | Precipitation (historical)                                | EDR            |
 
 To learn more about custom mappings, visit the [Western Water Datahub Mappings directory](./docs/mappings.md).
 
 ## Getting Started
 
-To run with Docker:
+In both development and containerized deployments, the server can be accessed at `http://localhost:5005`
+
+### Local Development
+
+- Spin up the redis db using `docker compose up -d`
+- To install dependencies run `make deps`
+  - We use [`uv`](https://github.com/astral-sh/uv) for dependency management and thus you should have it installed
+- To run the server run: `make dev`
+- To run tests run: `make test`
+
+### Containerized Deployment
+
+The following command will spin up all infrastructure for a containerized deployment and build both the server and UI as docker images
 
 ```bash
 docker compose --profile production up
 ```
 
-### Local Development
-
-- To install dependencies run `make deps`
-  - We use uv for dependency management and thus you should have it installed
-  - You can however also use the `requirements.txt` as well for quick checks as it is kept up to date automatically
-- To run the server run: `make dev`
-- To run the redis container for caching, run `docker compose up`
-- To run tests run: `make test`
+(Note: in production we deploy the pygeoapi server as a container on cloud run as defined by the [cloudbuild.yml](./cloudbuild.yml) file)
 
 ## Contributing
 
@@ -43,4 +50,4 @@ Contributions are welcome! Please open an issue or submit a pull request to help
 
 ## License
 
-This project is licensed under the MIT. See the `LICENSE` file for details.
+This project is licensed under the MIT license. See the [`LICENSE` file](./LICENSE) for details.

--- a/docs/mappings.md
+++ b/docs/mappings.md
@@ -11,8 +11,8 @@ These tables track the EDR implementation of each mapping in this repo [here](..
 | `RISE`               | ✅ / ✅                  | ✅          | ✅   | ✅       | ✅      | ✅            | ❌  | ❌           | ✅  |
 | `SNOTEL`             | ✅ / ✅                  | ✅          | ✅   | ✅       | ✅      | ✅            | ❌  | ❌           | ✅  |
 | `AWDB Forecasts`     | ✅ / ✅                  | ✅          | ✅   | ✅       | ✅      | ✅            | ❌  | ❌           | ✅  |
-| `USACE`              | ❌ / ❌                  | ❌          | ❌   | ❌       | ❌      | ❌            | ❌  | ❌           | ❌  |
-| `NOAA RFC Forecasts` | ✅ / ✅                  | ✅          | ❌   | ❌       | ✅      | ✅            | ❌  | ❌           | ✅  |
+| `USACE`              | ✅ / ✅                  | ✅          | ✅   | ✅       | ✅      | ✅            | ❌  | ❌           | ✅  |
+| `NOAA RFC Forecasts` | ✅ / ✅                  | ✅          | ✅   | ✅       | ✅      | ✅            | ❌  | ❌           | ✅  |
 
 ## OGC EDR Spec Compliance
 
@@ -21,7 +21,7 @@ These tables track the EDR implementation of each mapping in this repo [here](..
 | RISE           | ❌       | ❌     | ✅   | ✅   | ❌         | ❌        | ✅    |
 | SNOTEL         | ❌       | ❌     | ✅   | ✅   | ❌         | ❌        | ✅    |
 | AWDB Forecasts | ❌       | ❌     | ✅   | ✅   | ❌         | ❌        | ✅    |
-| USACE          | ❌       | ❌     | ❌   | ❌   | ❌         | ❌        | ❌    |
+| USACE          | ❌       | ❌     | ✅   | ✅   | ❌         | ❌        | ✅    |
 
 ### EDR Query Options
 
@@ -30,4 +30,4 @@ These tables track the EDR implementation of each mapping in this repo [here](..
 | RISE           | ✅     | ✅             | ✅       |
 | SNOTEL         | ✅     | ✅             | ✅       |
 | AWDB Forecasts | ✅     | ✅             | ✅       |
-| USACE          | ❌     | ❌             | ❌       |
+| USACE          | ✅     | ✅             | ✅       |

--- a/packages/usace/usace/lib/locations_collection.py
+++ b/packages/usace/usace/lib/locations_collection.py
@@ -190,7 +190,7 @@ class LocationCollection(LocationCollectionProtocolWithEDR):
         """
         Return all fields used for EDR queries
         """
-        # Two sets for running assertions against
+        # Set for running assertions against
         # We want to make sure we don't have params that are
         # the same location with
         # multiple parameters of the same category
@@ -212,7 +212,9 @@ class LocationCollection(LocationCollectionProtocolWithEDR):
                     # If the param already exists but has a different unit,
                     # that is a failure and would make the results ambiguous
                     unit = fields[param.label]["x-ogc-unit"]
-                    assert unit == param.unit
+                    assert unit == param.unit, (
+                        f"There are two parameters with the same label {param.label} but different units thus making it ambiguous"
+                    )
                 else:
                     fields[param.label] = {
                         "title": param.label,

--- a/packages/usace/usace/lib/locations_collection.py
+++ b/packages/usace/usace/lib/locations_collection.py
@@ -210,11 +210,9 @@ class LocationCollection(LocationCollectionProtocolWithEDR):
                 locationWithCategory.add((location.id, param.label))
                 if param.label in fields:
                     # If the param already exists but has a different unit,
-                    # add the new unit as another option in the field
+                    # that is a failure and would make the results ambiguous
                     unit = fields[param.label]["x-ogc-unit"]
                     assert unit == param.unit
-                    # if unit != param.unit:
-                    #     fields[param.label]["x-ogc-unit"] = f"{unit} / {param.unit}"
                 else:
                     fields[param.label] = {
                         "title": param.label,

--- a/packages/usace/usace/lib/locations_collection_test.py
+++ b/packages/usace/usace/lib/locations_collection_test.py
@@ -19,10 +19,10 @@ def test_get_edr_fields():
     collection = LocationCollection()
     fields = collection.get_fields()
     assert fields
-    assert fields["SC18.Elev.Inst.1Hour.0.Best-NWO"] == {
+    assert fields["Elevation"] == {
         "title": "Elevation",
         "type": "string",
-        "description": "Elevation (Feet) with id SC18.Elev.Inst.1Hour.0.Best-NWO",
+        "description": "Elevation",
         "x-ogc-unit": "ft",
     }
 

--- a/packages/usace/usace/lib/param_helpers.py
+++ b/packages/usace/usace/lib/param_helpers.py
@@ -1,0 +1,33 @@
+from usace.lib.locations_collection import LocationCollection
+from pygeoapi.provider.base import ProviderNoDataError
+
+
+def get_upstream_ids_of_select_properties(
+    # A list of properties that a user wants to select
+    properties_to_select: list[str],
+    # A list of locations that contain the properties with their original tsid
+    # This is used for joining against in order to map the tsid to the upstream id
+    location_collection: LocationCollection,
+) -> list:
+    """
+    Given a list of properties to select
+    """
+    labelToParams: dict[str, list[str]] = {}
+
+    for location in location_collection.locations:
+        params = location.properties.timeseries
+        if not params:
+            continue
+
+        for param in params:
+            if param.label not in properties_to_select:
+                continue
+            if param.label not in labelToParams:
+                labelToParams[param.label] = []
+            labelToParams[param.label].append(param.tsid)
+
+    # return all the properties that the user wants to select as one big list
+    result = [item for sublist in labelToParams.values() for item in sublist]
+    if result == []:
+        raise ProviderNoDataError("No data was found for the requested parameters")
+    return result

--- a/packages/usace/usace/lib/param_helpers.py
+++ b/packages/usace/usace/lib/param_helpers.py
@@ -1,3 +1,6 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
 from usace.lib.locations_collection import LocationCollection
 from pygeoapi.provider.base import ProviderNoDataError
 

--- a/packages/usace/usace/usace_edr.py
+++ b/packages/usace/usace/usace_edr.py
@@ -92,6 +92,9 @@ class USACEEDRProvider(BaseEDRProvider, EDRProviderProtocol):
 
         collection.drop_all_locations_outside_bounding_box(bbox, z)
 
+        # replace param with proper name
+        # collection.replace_param_names(select_properties)
+
         return collection.to_covjson(self.get_fields(), datetime_, select_properties)
 
     @otel_trace()

--- a/packages/usace/usace/usace_edr_test.py
+++ b/packages/usace/usace/usace_edr_test.py
@@ -1,0 +1,31 @@
+# Copyright 2025 Lincoln Institute of Land Policy
+# SPDX-License-Identifier: MIT
+
+
+import pytest
+from usace.usace_edr import USACEEDRProvider
+from pygeoapi.provider.base import ProviderNoDataError
+
+provider_def = {
+    "name": "test",
+    "type": "feature",
+    "data": "remote",
+}
+
+
+def test_usace_decode_param():
+    p = USACEEDRProvider(provider_def)
+    result = p.locations(
+        location_id="2796555126", select_properties=["Stage"], datetime_="2025-01-01/.."
+    )
+    assert result and "coverages" in result
+    assert len(result["coverages"]) == 1, (
+        "There should be one coverage for this location after filtering out the others"
+    )
+
+    with pytest.raises(ProviderNoDataError):
+        p.locations(
+            location_id="2796555126",
+            select_properties=["DUMMY"],
+            datetime_="2025-01-01/..",
+        )

--- a/packages/usace/usace/usace_test.py
+++ b/packages/usace/usace/usace_test.py
@@ -1,6 +1,0 @@
-# Copyright 2025 Lincoln Institute of Land Policy
-# SPDX-License-Identifier: MIT
-
-
-def test_usace_provider():
-    pass

--- a/pygeoapi-deployment/pygeoapi.config.yml
+++ b/pygeoapi-deployment/pygeoapi.config.yml
@@ -404,7 +404,7 @@ resources:
       - type: application/html
         rel: canonical
         title: data source
-        href: https://data.usbr.gov/
+        href: https://mapservices.weather.noaa.gov/vector/rest/services/precip/wpc_prob_winter_precip/MapServer
         hreflang: en-US
     extents:
       spatial:
@@ -426,7 +426,7 @@ resources:
       - type: application/html
         rel: canonical
         title: data source
-        href: https://data.usbr.gov/
+        href: https://mapservices.weather.noaa.gov/vector/rest/services/precip/wpc_prob_winter_precip/MapServer
         hreflang: en-US
     extents:
       spatial:
@@ -448,7 +448,7 @@ resources:
       - type: application/html
         rel: canonical
         title: data source
-        href: https://data.usbr.gov/
+        href: https://mapservices.weather.noaa.gov/vector/rest/services/precip/wpc_prob_winter_precip/MapServer
         hreflang: en-US
     extents:
       spatial:
@@ -470,7 +470,7 @@ resources:
       - type: application/html
         rel: canonical
         title: data source
-        href: https://data.usbr.gov/
+        href: https://mapservices.weather.noaa.gov/vector/rest/services/precip/wpc_prob_winter_precip/MapServer
         hreflang: en-US
     extents:
       spatial:


### PR DESCRIPTION
Add behavior to strip location data from the param when enumerating params and then readd it when you go to request data

Example: You can request the param category stage to filter this location here: (you dont need to request the direct upstream param that is messy and includes the location name in the param itself) http://localhost:5005/collections/usace-edr/locations/2796555126?f=json&datetime=2025-01-01/..&parameter-name=Stage

![image](https://github.com/user-attachments/assets/5db356a8-9594-4a52-8dc5-49d9067cada2)

New param list

![image](https://github.com/user-attachments/assets/31e01916-cb52-46d5-90db-d65100d79931)
