### PR TITLE
Revert "Optimize rise by caching more"

### DIFF
--- a/packages/rise/rise/lib/cache.py
+++ b/packages/rise/rise/lib/cache.py
@@ -4,6 +4,7 @@
 import asyncio
 import logging
 import math
+from typing import Optional
 from urllib.parse import urlparse
 from com.helpers import EDRFieldsMapping, await_
 from rise.custom_types import JsonPayload, Url
@@ -104,8 +105,9 @@ class RISECache(RedisCache):
         return fields
 
     @TRACER.start_as_current_span("get_or_fetch_all_param_filtered_pages")
-    def get_or_fetch_all_locations(
+    def get_or_fetch_all_param_filtered_pages(
         self,
+        properties_to_filter_by: Optional[list[str]] = None,
         only_include_locations_with_data: bool = True,
         force_fetch=False,
     ):
@@ -115,6 +117,12 @@ class RISECache(RedisCache):
         if only_include_locations_with_data:
             base_url += f"&{hasTimeseriesData}"
 
+        if properties_to_filter_by:
+            base_url += "&"
+            for prop in properties_to_filter_by:
+                assert isinstance(prop, str)
+                base_url += f"parameterId%5B%5D={prop}&"
+            base_url = base_url.removesuffix("&")
         return await_(self.get_or_fetch_all_pages(base_url, force_fetch=force_fetch))
 
     async def get_or_fetch_all_results(

--- a/packages/rise/rise/lib/covjson/covjson.py
+++ b/packages/rise/rise/lib/covjson/covjson.py
@@ -14,7 +14,6 @@ from com.covjson import (
 )
 from rise.lib.cache import RISECache
 from rise.lib.add_results import DataNeededForCovjson
-from pygeoapi.provider.base import ProviderNoDataError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -163,8 +162,6 @@ class CovJSONBuilder:
             paramIdToMetadata = {
                 k: v for k, v in paramIdToMetadata.items() if k in select_properties
             }
-            if not paramIdToMetadata:
-                raise ProviderNoDataError()
 
         templated_covjson["coverages"] = self._get_coverages(
             location_response, paramIdToMetadata

--- a/packages/rise/rise/lib/location.py
+++ b/packages/rise/rise/lib/location.py
@@ -445,14 +445,3 @@ class LocationCollectionWithIncluded(LocationCollection):
             seenLocations.add(location.attributes.locationName)
 
         return False
-
-    def drop_all_properties_but_selected(self, selected_properties: list[str]) -> None:
-        itemsToPop = set()
-        for i, included_item in enumerate(self.included):
-            if included_item.type == "CatalogItem":
-                if included_item.id in selected_properties:
-                    continue
-                itemsToPop.add(i)
-
-        for i in sorted(itemsToPop, reverse=True):
-            self.included.pop(i)

--- a/packages/rise/rise/lib/location_test.py
+++ b/packages/rise/rise/lib/location_test.py
@@ -79,7 +79,7 @@ def test_filter_by_wkt(oneItemLocationRespFixture: dict):
 def test_filter_everything_by_wkt():
     p = RiseEDRProvider()
     georgeWestTexasID291 = "POLYGON ((-98.66272 28.062286, -97.756348 28.062286, -97.756348 28.688178, -98.66272 28.688178, -98.66272 28.062286))"
-    raw_resp = p.cache.get_or_fetch_all_locations()
+    raw_resp = p.cache.get_or_fetch_all_param_filtered_pages()
     response = LocationResponse.from_api_pages(raw_resp)
     response.drop_outside_of_wkt(wkt=georgeWestTexasID291)
     length = len(response.locations)

--- a/packages/rise/rise/rise.py
+++ b/packages/rise/rise/rise.py
@@ -63,37 +63,35 @@ class RiseProvider(BaseProvider, OAFProviderProtocol):
 
         # we don't filter by parameters here since OAF filters features by
         # the attributes of the feature, not the parameters of the associated timeseries data
-        raw_resp = self.cache.get_or_fetch_all_locations(
+        raw_resp = self.cache.get_or_fetch_all_param_filtered_pages(
             only_include_locations_with_data=False
         )
-        collection = LocationResponse.from_api_pages_with_included_catalog_items(
-            raw_resp
-        )
+        response = LocationResponse.from_api_pages_with_included_catalog_items(raw_resp)
 
         if itemId:
-            collection.drop_all_locations_but_id(itemId)
+            response.drop_all_locations_but_id(itemId)
 
         if datetime_:
-            collection.drop_outside_of_date_range(datetime_)
+            response.drop_outside_of_date_range(datetime_)
 
         # Even though bbox is required, it can be an empty list. If it is empty just skip filtering
         if bbox:
-            collection.drop_outside_of_bbox(bbox)
+            response.drop_outside_of_bbox(bbox)
 
         if offset:
-            collection.drop_before_offset(offset)
+            response.drop_before_offset(offset)
 
         if limit:
-            collection.drop_after_limit(limit)
+            response.drop_after_limit(limit)
 
         if resulttype == "hits":
             return {
                 "type": "FeatureCollection",
                 "features": [],
-                "numberMatched": len(collection.locations),
+                "numberMatched": len(response.locations),
             }
 
-        return collection.to_geojson(
+        return response.to_geojson(
             itemsIDSingleFeature=itemId is not None,
             skip_geometry=skip_geometry,
             select_properties=select_properties,


### PR DESCRIPTION
The issue I am realizing with this PR is that there is no way to filter on parameters locally without doing an unreasonable number of fetches/local joins. You have to use the upstream parameter filter in the query url itself. 

If you try to curl and include parameters it doesn't fail but it also doesn't include them. So since it doesn't include them you need to fetch the catalog item, and then fetch the parameter for each one with is not feasible. 
```
curl -X 'GET' \
                                             'https://data.usbr.gov/rise/api/location/266&include=catalogRecords.parameters' \
                                             -H 'accept: application/vnd.api+json' | grep parameter
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1227    0  1227    0     0   3661      0 --:--:-- --:--:-- --:--:--  3673
```

Reverts internetofwater/Western-Water-Datahub#75