### PR TITLE
Fix covjson syntax/type  error

### DIFF
--- a/packages/awdb_forecasts/awdb_forecasts/lib/covjson_builder.py
+++ b/packages/awdb_forecasts/awdb_forecasts/lib/covjson_builder.py
@@ -71,7 +71,9 @@ class CovjsonBuilder(CovjsonBuilderProtocol):
                 domainType=DomainType.vertical_profile,
                 axes=Axes(
                     t=ValuesAxis(values=times),
-                    z=ValuesAxis(values=probabilities),
+                    z=ValuesAxis(
+                        dataType="float", values=[float(prob) for prob in probabilities]
+                    ),
                     x=ValuesAxis(values=[longitude]),
                     y=ValuesAxis(values=[latitude]),
                 ),
@@ -92,6 +94,7 @@ class CovjsonBuilder(CovjsonBuilderProtocol):
                         system=ReferenceSystem(
                             type="TemporalRS",
                             id="http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                            calendar="Gregorian",
                         ),
                     ),
                 ],


### PR DESCRIPTION
Fix an issue with the covjson where we needed to apply the calendar property and have the right type for the z axis