### PR TITLE
Feat: added reservoir config to handle multiple reservoir layers

### DIFF
--- a/dashboard-ui/e2e/Chart.spec.ts
+++ b/dashboard-ui/e2e/Chart.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ReservoirSource } from '@/features/Map/consts';
+import { RISEEDRReservoirSource } from '@/features/Map/consts';
 import { getDateRange } from '@/features/Reservior/utils';
 import { test, expect } from '@playwright/test';
 
@@ -19,7 +19,7 @@ test.describe('Line Chart', () => {
 
         await test.step('Loading Options', async () => {
             // Await data load into map
-            await page.waitForRequest(ReservoirSource);
+            await page.waitForRequest(RISEEDRReservoirSource);
         });
 
         await test.step('Select updates after selection', async () => {

--- a/dashboard-ui/e2e/Selectors.spec.ts
+++ b/dashboard-ui/e2e/Selectors.spec.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ReservoirSource } from '@/features/Map/consts';
+import { RISEEDRReservoirSource } from '@/features/Map/consts';
 import { test, expect } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
@@ -26,7 +26,7 @@ test.describe('Region', () => {
                         )
                 ),
                 // Load Reservoirs
-                page.waitForRequest(ReservoirSource),
+                page.waitForRequest(RISEEDRReservoirSource),
             ]);
         });
         const regionSelect = page.getByTestId('region-select');
@@ -88,7 +88,7 @@ test.describe('Reservoir', () => {
                         )
                 ),
                 // Load Reservoirs
-                page.waitForRequest(ReservoirSource),
+                page.waitForRequest(RISEEDRReservoirSource),
             ]);
         });
 

--- a/dashboard-ui/src/features/Header/Filters.tsx
+++ b/dashboard-ui/src/features/Header/Filters.tsx
@@ -7,14 +7,11 @@ import { Group, Switch } from '@mantine/core';
 import styles from '@/features/Header/Header.module.css';
 import { useEffect, useState } from 'react';
 import { useMap } from '@/contexts/MapContexts';
-import {
-    LayerId,
-    MAP_ID,
-    ReserviorIconImageExpression,
-} from '@/features/Map/consts';
+import { MAP_ID, ReservoirConfigs } from '@/features/Map/consts';
+import { getReservoirIconImageExpression } from '@/features/Map/utils';
 
 export const Filters: React.FC = () => {
-    const [showTeacups, setShowTeacups] = useState(false);
+    const [showTeacups, setShowTeacups] = useState(true);
 
     const { map } = useMap(MAP_ID);
 
@@ -22,27 +19,22 @@ export const Filters: React.FC = () => {
         if (!map) {
             return;
         }
-
-        const iconImage = map.getLayoutProperty(
-            LayerId.Reservoirs,
-            'icon-image'
-        );
-
-        setShowTeacups(iconImage !== 'default');
-    }, [map]);
-
-    useEffect(() => {
-        if (!map) {
-            return;
-        }
         if (showTeacups) {
-            map.setLayoutProperty(
-                LayerId.Reservoirs,
-                'icon-image',
-                ReserviorIconImageExpression
+            ReservoirConfigs.forEach((config) =>
+                config.connectedLayers.forEach((layerId) =>
+                    map.setLayoutProperty(
+                        layerId,
+                        'icon-image',
+                        getReservoirIconImageExpression(config)
+                    )
+                )
             );
         } else {
-            map.setLayoutProperty(LayerId.Reservoirs, 'icon-image', 'default');
+            ReservoirConfigs.forEach((config) =>
+                config.connectedLayers.forEach((layerId) =>
+                    map.setLayoutProperty(layerId, 'icon-image', 'default')
+                )
+            );
         }
     }, [showTeacups]);
 

--- a/dashboard-ui/src/features/Header/Selectors/utils.ts
+++ b/dashboard-ui/src/features/Header/Selectors/utils.ts
@@ -4,18 +4,21 @@
  */
 
 import { SourceId } from '@/features/Map/consts';
-import { ComboboxData, ComboboxItem } from '@mantine/core';
+import { ComboboxItem } from '@mantine/core';
 import { Feature, GeoJsonProperties, Geometry } from 'geojson';
 import { ExpressionSpecification, Map as MapObj } from 'mapbox-gl';
+
+export type ItemWithSource = ComboboxItem & { source?: string };
 
 export const formatOptions = (
     features: Feature<Geometry, GeoJsonProperties>[],
     getValueProperty: (feature: Feature<Geometry, GeoJsonProperties>) => string,
     getLabelProperty: (feature: Feature<Geometry, GeoJsonProperties>) => string,
     defaultLabel: string = 'All',
-    defaultValue: string = 'all'
-): ComboboxData => {
-    const options = new Map<string, ComboboxItem>();
+    defaultValue: string = 'all',
+    source?: string
+): ItemWithSource[] => {
+    const options = new Map<string, ItemWithSource>();
     options.set('all', { value: defaultValue, label: defaultLabel });
     features.forEach((feature) => {
         if (feature.properties) {
@@ -27,6 +30,7 @@ export const formatOptions = (
                 options.set(value, {
                     value: value,
                     label: label,
+                    source,
                 });
             }
         }
@@ -44,7 +48,7 @@ export const createOptionsFromMapboxSource = (
     getValueProperty: (feature: Feature<Geometry, GeoJsonProperties>) => string,
     getLabelProperty: (feature: Feature<Geometry, GeoJsonProperties>) => string,
     defaultLabel: string
-): ComboboxData => {
+): ComboboxItem[] => {
     const features = map.querySourceFeatures(sourceId, {
         sourceLayer: sourceId,
     });
@@ -68,7 +72,7 @@ export const createFilteredOptionsFromMapboxSource = (
     getValueProperty: (feature: Feature<Geometry, GeoJsonProperties>) => string,
     getLabelProperty: (feature: Feature<Geometry, GeoJsonProperties>) => string,
     defaultLabel: string
-): ComboboxData => {
+): ComboboxItem[] => {
     const features = map.querySourceFeatures(sourceId, {
         sourceLayer: sourceId,
         filter: filter,

--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -20,10 +20,13 @@ import {
     SubLayerId,
     LayerId,
     SourceId,
-    ReserviorIconImageExpression,
-    ReservoirSource,
+    RISEEDRReservoirSource,
     RegionsSource,
 } from '@/features/Map/consts';
+import {
+    getReservoirConfig,
+    getReservoirIconImageExpression,
+} from '@/features/Map/utils';
 
 /**********************************************************************
  * Define the various datasources this map will use
@@ -43,12 +46,12 @@ export const sourceConfigs: SourceConfig[] = [
         },
     },
     {
-        id: SourceId.Reservoirs,
+        id: SourceId.RiseEDRReservoirs,
         type: Sources.GeoJSON,
         definition: {
             type: 'geojson',
 
-            data: ReservoirSource,
+            data: RISEEDRReservoirSource,
             filter: ['!=', ['get', '_id'], 3688],
         },
     },
@@ -112,7 +115,7 @@ export const getLayerColor = (
             return '#F00';
         case LayerId.Basins:
             return '#0F0';
-        case LayerId.Reservoirs:
+        case LayerId.RiseEDRReservoirs:
             return '#00F';
         default:
             return '#FFF';
@@ -196,13 +199,15 @@ export const getLayerConfig = (
                     'fill-opacity': 0.3,
                 },
             };
-        case LayerId.Reservoirs:
+        case LayerId.RiseEDRReservoirs:
             return {
-                id: LayerId.Reservoirs,
+                id: LayerId.RiseEDRReservoirs,
                 type: LayerType.Symbol,
-                source: SourceId.Reservoirs,
+                source: SourceId.RiseEDRReservoirs,
                 layout: {
-                    'icon-image': ReserviorIconImageExpression,
+                    'icon-image': getReservoirIconImageExpression(
+                        getReservoirConfig(SourceId.RiseEDRReservoirs)!
+                    ),
                     'icon-size': [
                         'let',
                         'capacity',
@@ -418,11 +423,11 @@ export const layerDefinitions: MainLayerDefinition[] = [
         ],
     },
     {
-        id: LayerId.Reservoirs,
-        config: getLayerConfig(LayerId.Reservoirs),
+        id: LayerId.RiseEDRReservoirs,
+        config: getLayerConfig(LayerId.RiseEDRReservoirs),
         controllable: false,
         legend: false,
-        clickFunction: getLayerClickFunction(LayerId.Reservoirs),
+        clickFunction: getLayerClickFunction(LayerId.RiseEDRReservoirs),
         // hoverFunction: getLayerHoverFunction(LayerId.Reservoirs),
     },
 ];

--- a/dashboard-ui/src/features/Map/consts.ts
+++ b/dashboard-ui/src/features/Map/consts.ts
@@ -6,7 +6,6 @@
 import { basemaps } from '@/components/Map/consts';
 import { BasemapId } from '@/components/Map/types';
 import { ExpressionSpecification } from 'mapbox-gl';
-import { FeatureCollection, GeoJsonProperties, Geometry } from 'geojson';
 import { ReservoirConfig } from '@/features/Map/types';
 
 export const MAP_ID = 'main';
@@ -113,16 +112,6 @@ export const RISEEDRReservoirSource =
 export const RegionsSource =
     'https://services1.arcgis.com/ixD30sld6F8MQ7V5/arcgis/rest/services/ReclamationBoundariesFL/FeatureServer/0';
 
-export const getDefaultGeoJSON = (): FeatureCollection<
-    Geometry,
-    GeoJsonProperties
-> => {
-    return {
-        type: 'FeatureCollection',
-        features: [],
-    };
-};
-
 /**
  *
  * @constant
@@ -130,7 +119,7 @@ export const getDefaultGeoJSON = (): FeatureCollection<
 export const ReservoirConfigs: ReservoirConfig[] = [
     {
         id: SourceId.RiseEDRReservoirs,
-        storageProperty: 'Live Capcity',
+        storageProperty: 'Live Capcity', // Mock value, stand in for current storage
         capacityProperty: 'Active Capacity',
         identifierProperty: '_id',
         identifierType: 'number',

--- a/dashboard-ui/src/features/Map/consts.ts
+++ b/dashboard-ui/src/features/Map/consts.ts
@@ -7,6 +7,7 @@ import { basemaps } from '@/components/Map/consts';
 import { BasemapId } from '@/components/Map/types';
 import { ExpressionSpecification } from 'mapbox-gl';
 import { FeatureCollection, GeoJsonProperties, Geometry } from 'geojson';
+import { ReservoirConfig } from '@/features/Map/types';
 
 export const MAP_ID = 'main';
 
@@ -18,14 +19,15 @@ export const INITIAL_ZOOM = 4;
 export enum SourceId {
     Regions = 'regions-source',
     Basins = 'hu04',
-    Reservoirs = 'reservoirs-source',
+    RiseEDRReservoirs = 'rise-edr',
+    USACEEDRReservoirs = 'usace-edr',
     SnowWater = 'snow-water',
 }
 
 export enum LayerId {
     Regions = 'regions-main',
     Basins = 'basins-main',
-    Reservoirs = 'reservoirs',
+    RiseEDRReservoirs = 'rise-edr-reservoir-points',
     SnowWater = 'snow-water',
 }
 
@@ -41,7 +43,7 @@ export const allLayerIds = [
     ...Object.values(SubLayerId),
 ];
 
-const TeacupStepExpression: ExpressionSpecification = [
+export const TeacupStepExpression: ExpressionSpecification = [
     'step',
     ['var', 'storage'],
     'default', // Below first step value
@@ -87,40 +89,6 @@ const TeacupStepExpression: ExpressionSpecification = [
     'teacup-100',
 ];
 
-export const ReserviorIconImageExpression: ExpressionSpecification = [
-    'let',
-    'capacity', // Variable name
-    ['coalesce', ['get', 'Active Capacity'], 1], // Variable value
-    'storage', // Variable name
-    [
-        '/',
-        ['/', ['coalesce', ['get', 'Live Capcity'], 1], 2], // Mock value, stand in for current storage
-        ['coalesce', ['get', 'Active Capacity'], 1],
-    ], // Variable value
-    [
-        'step',
-        ['zoom'],
-        TeacupStepExpression,
-
-        ...[
-            [0, 2010000],
-            [4, 465000],
-            [5, 320000],
-            [7, 65000],
-            [8, -1],
-        ].flatMap(([zoom, capacity]) => [
-            zoom, // At this zoom
-            [
-                // Evaluate this expression
-                'case',
-                ['>=', ['var', 'capacity'], capacity],
-                TeacupStepExpression, // If GTE capacity, evaluate sub-step expression
-                'default', // Fallback to basic point symbol
-            ],
-        ]),
-    ],
-];
-
 /**
  *
  * @constant
@@ -138,20 +106,36 @@ export const ComplexReservoirProperties = [
  *
  * @constant
  */
-export const ReservoirIdentifierField = '_id';
-export const ReservoirLabelField = 'name';
-/**
- *
- * @constant
- */
 export const ReservoirRegionConnectorField = 'locationRegionNames';
 
-export const ReservoirSource =
+export const RISEEDRReservoirSource =
     'https://api.wwdh.internetofwater.app/collections/rise-edr/locations?f=json&parameter-name=reservoirStorage';
 export const RegionsSource =
     'https://services1.arcgis.com/ixD30sld6F8MQ7V5/arcgis/rest/services/ReclamationBoundariesFL/FeatureServer/0';
 
-export const defaultGeoJson: FeatureCollection<Geometry, GeoJsonProperties> = {
-    type: 'FeatureCollection',
-    features: [],
+export const getDefaultGeoJSON = (): FeatureCollection<
+    Geometry,
+    GeoJsonProperties
+> => {
+    return {
+        type: 'FeatureCollection',
+        features: [],
+    };
 };
+
+/**
+ *
+ * @constant
+ */
+export const ReservoirConfigs: ReservoirConfig[] = [
+    {
+        id: SourceId.RiseEDRReservoirs,
+        storageProperty: 'Live Capcity',
+        capacityProperty: 'Active Capacity',
+        identifierProperty: '_id',
+        identifierType: 'number',
+        labelProperty: 'name',
+        regionConnectorProperty: 'locationRegionNames',
+        connectedLayers: [LayerId.RiseEDRReservoirs],
+    },
+];

--- a/dashboard-ui/src/features/Map/types.ts
+++ b/dashboard-ui/src/features/Map/types.ts
@@ -4,6 +4,7 @@
  */
 
 import { MapSourceDataEvent, Map } from 'mapbox-gl';
+import { LayerId, SourceId } from '@/features/Map/consts';
 
 /**
  *
@@ -80,3 +81,18 @@ export type SourceDataEvent = {
     type: 'sourcedata';
     target: Map;
 } & MapSourceDataEvent;
+
+/**
+ *
+ * @type
+ */
+export type ReservoirConfig = {
+    id: SourceId;
+    storageProperty: string;
+    capacityProperty: string;
+    identifierProperty: string;
+    identifierType: 'string' | 'number';
+    labelProperty: string;
+    regionConnectorProperty: string;
+    connectedLayers: LayerId[];
+};

--- a/dashboard-ui/src/features/Map/utils.ts
+++ b/dashboard-ui/src/features/Map/utils.ts
@@ -16,6 +16,7 @@ import {
     TeacupStepExpression,
 } from '@/features/Map/consts';
 import { SourceId } from '@/features/Map/consts';
+import { FeatureCollection, GeoJsonProperties, Geometry } from 'geojson';
 
 /**
  *
@@ -68,7 +69,7 @@ export const parseReservoirProperties = <
 };
 
 /**
-
+ *
  * @function
  */
 export const isSourceDataLoaded = (
@@ -85,7 +86,7 @@ export const isSourceDataLoaded = (
 };
 
 /**
-
+ *
  * @function
  */
 export const getReservoirConfig = (id: SourceId): ReservoirConfig | null => {
@@ -93,7 +94,7 @@ export const getReservoirConfig = (id: SourceId): ReservoirConfig | null => {
 };
 
 /**
-
+ *
  * @function
  */
 export const getReservoirIconImageExpression = (
@@ -106,7 +107,7 @@ export const getReservoirIconImageExpression = (
         'storage', // Variable name
         [
             '/',
-            ['/', ['coalesce', ['get', config.storageProperty], 1], 2], // Mock value, stand in for current storage
+            ['/', ['coalesce', ['get', config.storageProperty], 1], 2],
             ['coalesce', ['get', config.capacityProperty], 1],
         ], // Variable value
         [
@@ -132,4 +133,18 @@ export const getReservoirIconImageExpression = (
             ]),
         ],
     ];
+};
+
+/**
+ *
+ * @function
+ */
+export const getDefaultGeoJSON = (): FeatureCollection<
+    Geometry,
+    GeoJsonProperties
+> => {
+    return {
+        type: 'FeatureCollection',
+        features: [],
+    };
 };

--- a/dashboard-ui/src/features/Reservior/Info.tsx
+++ b/dashboard-ui/src/features/Reservior/Info.tsx
@@ -5,7 +5,7 @@
 
 import { Paper, Stack, Title, Text, Group } from '@mantine/core';
 import PDF from '@/features/Reservior/PDF';
-import { ReservoirProperties } from '../Map/types';
+import { ReservoirProperties } from '@/features/Map/types';
 import { Chart as ChartJS } from 'chart.js';
 import { RefObject } from 'react';
 import styles from '@/features/Reservior/Reservoir.module.css';

--- a/dashboard-ui/src/lib/main.ts
+++ b/dashboard-ui/src/lib/main.ts
@@ -4,8 +4,8 @@
  */
 
 import { BasemapId } from '@/components/Map/types';
-import { ReservoirProperties } from '@/features/Map/types';
-import { FeatureCollection, Point } from 'geojson';
+import { SourceId } from '@/features/Map/consts';
+import { FeatureCollection, GeoJsonProperties, Point } from 'geojson';
 import { create } from 'zustand';
 
 export enum Tools {
@@ -15,25 +15,32 @@ export enum Tools {
 
 export type ReservoirStorageData = Array<{ x: string; y: number }>;
 
-export const ReservoirDefault = 0;
+export const ReservoirDefault = null;
 
-interface MainState {
+export type ReservoirCollections = {
+    [key in SourceId]?: FeatureCollection<Point, GeoJsonProperties>;
+};
+
+export type Reservoir = {
+    identifier: string | number;
+    source: string;
+};
+
+export interface MainState {
     region: string;
     setRegion: (region: string) => void;
     basin: string;
     setBasin: (basin: string) => void;
     system: string;
     setSystem: (system: string) => void;
-    reservoir: number;
-    setReservoir: (reservoir: number) => void;
-    reservoirCollection: FeatureCollection<Point, ReservoirProperties> | null;
-    setReservoirCollection: (
-        reservoirCollection: FeatureCollection<Point, ReservoirProperties>
+    reservoir: Reservoir | null;
+    setReservoir: (reservoir: Reservoir | null) => void;
+    reservoirCollections: ReservoirCollections | null;
+    setReservoirCollections: (
+        reservoirCollection: ReservoirCollections
     ) => void;
     basemap: BasemapId;
     setBasemap: (basemap: BasemapId) => void;
-    reservoirStorageData: Array<{ x: string; y: number }>;
-    setReservoirStorageData: (basemap: Array<{ x: string; y: number }>) => void;
     chartUpdate: number;
     setChartUpdate: (chartUpdate: number) => void;
     tools: {
@@ -52,14 +59,11 @@ const useMainStore = create<MainState>()((set) => ({
     setSystem: (system) => set({ system }),
     reservoir: ReservoirDefault,
     setReservoir: (reservoir) => set({ reservoir }),
-    reservoirCollection: null,
-    setReservoirCollection: (reservoirCollection) =>
-        set({ reservoirCollection }),
+    reservoirCollections: null,
+    setReservoirCollections: (reservoirCollection) =>
+        set({ reservoirCollections: reservoirCollection }),
     basemap: BasemapId.Standard,
     setBasemap: (basemap) => set({ basemap }),
-    reservoirStorageData: [],
-    setReservoirStorageData: (reservoirStorageData) =>
-        set({ reservoirStorageData }),
     chartUpdate: 0,
     setChartUpdate: (chartUpdate) => set({ chartUpdate }),
     tools: {


### PR DESCRIPTION
### Description:
This update should be functionally identical to the [previous ](https://github.com/internetofwater/Western-Water-Datahub/pull/88) update to the dashboard. In the code, I've updated the logic to handle multiple sources for reservoir points that should hopefully make adding additional reservoir sources as simple as adding another config entry.

### To Test (copied from pr 88):
1. From the starting view, zoom in
2. Smaller capacity reservoirs should render in at higher zoom levels with smaller icons
3. In the controls revealed by the Filters button, the "Show Teacups" button should toggle the teacup icon on/off
4. Teacups should always show the largest capacity reservoir when there is an overlap of icons
5. Teacup rendering logic should persist when switching basemaps
6. Selecting a Reservoir on the map or in the select should trigger a fly to operation that zooms into the reservoir
7. Selecting the Clear All button next to the selectors in the header should clear all choices and reset the map to its initial view