### PR TITLE
Decrease space taken up header by condensing top bars

### DIFF
--- a/dashboard-ui/src/features/Header/index.tsx
+++ b/dashboard-ui/src/features/Header/index.tsx
@@ -28,14 +28,10 @@ const Header: React.FC = () => {
     const [opened, { toggle }] = useDisclosure(false);
 
     return (
-        <>
-            <Box component="div" className={styles.topBarContainer}>
-                <Paper
-                    radius={0}
-                    shadow="xs"
-                    className={`${styles.topBarPaper} ${styles.logoBarPaper}`}
-                >
-                    <Group justify="space-between" align="center">
+        <Box component="div" className={styles.topBarContainer}>
+            <Paper radius={0} shadow="xs" className={styles.topBarPaper}>
+                <Group justify="space-between" align="center">
+                    <Group gap="xl">
                         <Box component="span" darkHidden>
                             <Image
                                 src={'/BofR-logo-dark.png'}
@@ -56,30 +52,24 @@ const Header: React.FC = () => {
                             <DarkModeToggle />
                         </Suspense>
                     </Group>
-                </Paper>
-            </Box>
-            <Box component="div" className={styles.topBarContainer}>
-                <Paper radius={0} shadow="xs" className={styles.topBarPaper}>
-                    <Group justify="space-between">
-                        <Group gap="xl">
-                            <Region />
-                            <Basin />
-                            {/* Group these so they move together when decreasing screen width */}
-                            <Group>
-                                <Reservoir />
-                                <ClearAll />
-                            </Group>
+                    <Group gap="lg">
+                        <Region />
+                        <Basin />
+                        {/* Group these so they move together when decreasing screen width */}
+                        <Group>
+                            <Reservoir />
+                            <ClearAll />
                         </Group>
-                        <Button variant="default" onClick={toggle}>
-                            Show Filters
-                        </Button>
                     </Group>
-                    <Collapse in={opened}>
-                        <Filters />
-                    </Collapse>
-                </Paper>
-            </Box>
-        </>
+                    <Button variant="default" onClick={toggle}>
+                        Show Filters
+                    </Button>
+                </Group>
+                <Collapse in={opened}>
+                    <Filters />
+                </Collapse>
+            </Paper>
+        </Box>
     );
 };
 


### PR DESCRIPTION
This might not be the right fit but played around with putting the logo and the other region toggles on the same bar to save screen real estate and allow for a bigger map

![image](https://github.com/user-attachments/assets/1413acd2-a57e-48aa-aff9-a3b2bc2d348d)


**can't figure out how to get rid of this extra padding at the top of the map though**

![image](https://github.com/user-attachments/assets/dcdd6ca2-d28c-418a-91d0-50c4e942ced6)
