### PR TITLE
Use native gdal python bindings

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -17,7 +17,7 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@v1.4.3
         with:
           packages: gdal-bin libgdal-dev
-          version: 3.8.4
+          version: 3.6.4
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -13,6 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install GDAL with Python bindings
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+        with:
+          packages: gdal-bin libgdal-dev
+          version: 3.8.4
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
 
   database:
     image: postgis/postgis:14-3.2-alpine
+    shm_size: 2g
     env_file:
       - .env.example
     ports:

--- a/packages/resviz/pyproject.toml
+++ b/packages/resviz/pyproject.toml
@@ -8,6 +8,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "GDAL==3.6.4",
     "geoalchemy2>=0.17.1",
     "pg-edr @ git+https://github.com/internetofwater/pgedr.git@main",
     "psycopg2>=2.9.10",

--- a/packages/resviz/resviz.sh
+++ b/packages/resviz/resviz.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright 2025 Lincoln Institute of Land Policy
 # SPDX-License-Identifier: MIT
 

--- a/packages/resviz/resviz/__init__.py
+++ b/packages/resviz/resviz/__init__.py
@@ -33,7 +33,7 @@ def run_subprocess(csv_url: str):
 
     # Open the CSV datasource
     csv_driver = ogr.GetDriverByName("CSV")
-    csv_ds = csv_driver.Open(f"/vsicurl/{csv_url}", 0) # 0 for update mode
+    csv_ds = csv_driver.Open(f"/vsicurl/{csv_url}", 0)  # 0 for update mode
     if csv_ds is None:
         LOGGER.warning(f"Could not open CSV file: {csv_url}")
         return

--- a/packages/resviz/resviz/__init__.py
+++ b/packages/resviz/resviz/__init__.py
@@ -37,16 +37,16 @@ def run_subprocess(csv_url: str):
     if csv_ds is None:
         LOGGER.warning(f"Could not open CSV file: {csv_url}")
         return
-    
+
     # Get the source layer.
     layer = csv_ds.GetLayer()
     layer_def = layer.GetLayerDefn()
 
     # Open the PostgreSQL datasource
     pg_driver = ogr.GetDriverByName("PostgreSQL")
-    pg_ds = pg_driver.Open(POSTGRES_URL, 1) # 1 for update mode
+    pg_ds = pg_driver.Open(POSTGRES_URL, 1)  # 1 for update mode
     if pg_ds is None:
-        LOGGER.error(f"Could not open PostgreSQL database")
+        LOGGER.error("Could not open PostgreSQL database")
 
     # Get the target layer.
     pg_layer = pg_ds.GetLayerByName("resviz")
@@ -54,8 +54,7 @@ def run_subprocess(csv_url: str):
     # Process source 'layer'
     for feature in layer:
         row = {
-            layer_def.GetFieldDefn(i).GetName().strip(): 
-            feature.GetField(i).strip()
+            layer_def.GetFieldDefn(i).GetName().strip(): feature.GetField(i).strip()
             for i in range(layer_def.GetFieldCount())
         }
 

--- a/packages/resviz/resviz/__init__.py
+++ b/packages/resviz/resviz/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import click
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 from dateutil.parser import parse as dateparse
 
 import logging
@@ -57,6 +57,10 @@ def run_subprocess(csv_url: str):
             layer_def.GetFieldDefn(i).GetName().strip(): feature.GetField(i).strip()
             for i in range(layer_def.GetFieldCount())
         }
+
+        row["DataDate"] = datetime.strptime(row["DataDate"], "%m/%d/%Y").strftime(
+            "%Y-%m-%d"
+        )
 
         # Upsert data value
         create_feature(pg_layer, row, 3)

--- a/packages/resviz/resviz/__init__.py
+++ b/packages/resviz/resviz/__init__.py
@@ -33,7 +33,7 @@ def run_subprocess(csv_url: str):
 
     # Open the CSV datasource
     csv_driver = ogr.GetDriverByName("CSV")
-    csv_ds = csv_driver.Open(f"/vsicurl/{csv_url}", 0)
+    csv_ds = csv_driver.Open(f"/vsicurl/{csv_url}", 0) # 0 for update mode
     if csv_ds is None:
         LOGGER.warning(f"Could not open CSV file: {csv_url}")
         return

--- a/packages/resviz/resviz/lib.py
+++ b/packages/resviz/resviz/lib.py
@@ -1,49 +1,14 @@
 # Copyright 2025 Lincoln Institute of Land Policy
 # SPDX-License-Identifier: MIT
 
-from datetime import timedelta, date
+from copy import deepcopy
+from datetime import timedelta, date, datetime
+from osgeo import ogr, gdal
+import re
 import requests
-import pandas as pd
-
 from typing import Iterator
 
-# GDAL VRT template
-VRT_TEMPLATE = """<OGRVRTDataSource>
-  <OGRVRTLayer name="input">
-    <SrcDataSource>{file}</SrcDataSource>
-    <GeometryType>wkbPoint</GeometryType>
-    <LayerSRS>EPSG:4326</LayerSRS>
-    <FID />
-    <Field name="SiteShortName" type="String" />
-    <Field name="SiteName"      type="String" />
-    <Field name="State"         type="String" />
-    <Field name="DoiRegion"     type="String" />
-    <Field name="DataValue"     type="Real" />
-    <Field name="DataUnits"     type="String" />
-    <Field name="DataDate"      type="String" />
-    <Field name="TeacupUrl"     type="String" />
-    <Field name="MaxCapacity"   type="Integer" />
-    <GeometryField name="geom" encoding="PointFromColumns" x="Lon" y="Lat" />
-  </OGRVRTLayer>
-</OGRVRTDataSource>"""
-
-# GDAL Select insert
-VRT_ROW = """
-SELECT 
-  CONCAT(SiteShortName, '.', DataDate) AS id,
-  SiteShortName AS monitoring_location_id,
-  SiteName AS site_name,
-  State AS state,
-  DoiRegion AS doi_region,
-  DataValue AS value,
-  MaxCapacity AS max_capacity,
-  DataDate AS data_date,
-  'Lake/Reservoir Storage' AS parameter_name,
-  3 AS parameter_id,
-  DataUnits AS parameter_unit,
-  geom
-FROM input
-"""
+gdal.UseExceptions()
 
 
 def file_exists(url: str) -> bool:
@@ -55,28 +20,62 @@ def file_exists(url: str) -> bool:
         return False
 
 
-def fetch_csv(url: str) -> pd.DataFrame:
-    """Fetch CSV and insert into pandas dataframe"""
-    df = pd.read_csv(url, skipinitialspace=True)
-
-    # Strip excess whitespace because the csv does not
-    # conform to https://www.rfc-editor.org/rfc/rfc4180
-    df.columns = df.columns.str.strip()
-    for col in df.select_dtypes(include="object"):
-        df[col] = df[col].str.strip()
-
-    # Format date as ISO8601 compatible
-    df["DataDate"] = pd.to_datetime(df["DataDate"], errors="coerce").dt.strftime(
-        "%Y-%m-%d"
-    )
-
-    # Create URL friendly monitoring location identifier
-    df["SiteShortName"] = df["TeacupUrl"].str.extract(r"/([^/]+)\.png$")[0]
-
-    return df
-
-
 def date_range(start_date: date, end_date: date) -> Iterator[date]:
     """Create an iterator of Datetime objects between period"""
     for n in range(int((end_date - start_date).days) + 1):
         yield start_date + timedelta(n)
+
+
+def create_feature(pg_layer, row, parameter):
+    """Create postgres feature from a CSV row"""
+    row = deepcopy(row)
+    p_name = "Lake/Reservoir Storage"
+
+    match parameter:
+        case 0:
+            p_name = "Min" + p_name
+            p_val = "DataDateMin"
+            p_suffix = "min"
+        case 1:
+            p_name = "Avg" + p_name
+            p_val = "DataDateAvg"
+            p_suffix = "avg"
+        case 2:
+            p_name = "Max" + p_name
+            p_val = "DataDateMax"
+            p_suffix = "max"
+        case _:
+            p_val = "DataValue"
+            p_suffix = "value"
+
+    row["DataDate"] = datetime.strptime(
+        row["DataDate"], "%m/%d/%Y"
+    ).strftime("%Y-%m-%d")
+    row["SiteShortName"] = re.search(
+        r"/([^/]+)\.png$", row["TeacupUrl"]
+    ).group(1) # pyright: ignore
+
+    feature = ogr.Feature(pg_layer.GetLayerDefn())
+    id = f"{row["SiteShortName"]}.{row["DataDate"]}.{p_suffix}"
+    feature.SetField("id", id)
+    feature.SetField("monitoring_location_id", row["SiteShortName"])
+    feature.SetField("site_name", row["SiteName"])
+    feature.SetField("state", row["State"])
+    feature.SetField("doi_region", row["DoiRegion"])
+    feature.SetField("value", row[p_val])
+    feature.SetField("max_capacity", row["MaxCapacity"])
+    feature.SetField("parameter_unit", row["DataUnits"])
+    feature.SetField("data_date", row["DataDate"])
+    feature.SetField("parameter_name", p_name)
+    feature.SetField("parameter_id", parameter)
+
+    point = ogr.Geometry(ogr.wkbPoint)
+    point.SetPoint_2D(0, float(row["Lon"]), float(row["Lat"]))
+    feature.SetGeometry(point)
+
+    try:
+        pg_layer.CreateFeature(feature)
+    except RuntimeError:
+        pass
+    finally:
+        feature = None # Release feature

--- a/packages/resviz/resviz/lib.py
+++ b/packages/resviz/resviz/lib.py
@@ -1,8 +1,7 @@
 # Copyright 2025 Lincoln Institute of Land Policy
 # SPDX-License-Identifier: MIT
 
-from copy import deepcopy
-from datetime import timedelta, date, datetime
+from datetime import timedelta, date
 from osgeo import ogr, gdal
 import re
 import requests
@@ -28,7 +27,6 @@ def date_range(start_date: date, end_date: date) -> Iterator[date]:
 
 def create_feature(pg_layer, row, parameter):
     """Create postgres feature from a CSV row"""
-    row = deepcopy(row)
     p_name = "Lake/Reservoir Storage"
 
     match parameter:
@@ -48,9 +46,6 @@ def create_feature(pg_layer, row, parameter):
             p_val = "DataValue"
             p_suffix = "value"
 
-    row["DataDate"] = datetime.strptime(row["DataDate"], "%m/%d/%Y").strftime(
-        "%Y-%m-%d"
-    )
     row["SiteShortName"] = re.search(r"/([^/]+)\.png$", row["TeacupUrl"]).group(1)  # pyright: ignore
 
     feature = ogr.Feature(pg_layer.GetLayerDefn())

--- a/packages/resviz/resviz/lib.py
+++ b/packages/resviz/resviz/lib.py
@@ -48,15 +48,13 @@ def create_feature(pg_layer, row, parameter):
             p_val = "DataValue"
             p_suffix = "value"
 
-    row["DataDate"] = datetime.strptime(
-        row["DataDate"], "%m/%d/%Y"
-    ).strftime("%Y-%m-%d")
-    row["SiteShortName"] = re.search(
-        r"/([^/]+)\.png$", row["TeacupUrl"]
-    ).group(1) # pyright: ignore
+    row["DataDate"] = datetime.strptime(row["DataDate"], "%m/%d/%Y").strftime(
+        "%Y-%m-%d"
+    )
+    row["SiteShortName"] = re.search(r"/([^/]+)\.png$", row["TeacupUrl"]).group(1)  # pyright: ignore
 
     feature = ogr.Feature(pg_layer.GetLayerDefn())
-    id = f"{row["SiteShortName"]}.{row["DataDate"]}.{p_suffix}"
+    id = f"{row['SiteShortName']}.{row['DataDate']}.{p_suffix}"
     feature.SetField("id", id)
     feature.SetField("monitoring_location_id", row["SiteShortName"])
     feature.SetField("site_name", row["SiteName"])
@@ -78,4 +76,4 @@ def create_feature(pg_layer, row, parameter):
     except RuntimeError:
         pass
     finally:
-        feature = None # Release feature
+        feature = None  # Release feature

--- a/packages/resviz/schema.sql
+++ b/packages/resviz/schema.sql
@@ -120,7 +120,7 @@ CREATE TABLE public.resviz (
     doi_region character varying,
     value double precision,
     max_capacity integer,
-    data_date character varying,
+    data_date date,
     parameter_name character varying,
     parameter_id integer,
     parameter_unit character varying,
@@ -172,17 +172,23 @@ ALTER TABLE ONLY public.resviz
 
 
 --
--- Name: covjson; Type: INDEX; Schema: public; Owner: -
+-- Name: covjson_param_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX covjson ON public.resviz USING btree (monitoring_location_id, parameter_id, data_date desc, value);
+CREATE INDEX covjson_param_idx ON public.resviz (parameter_id, monitoring_location_id) INCLUDE (parameter_name, parameter_unit);
+
+--
+-- Name: covjson_time_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX covjson_time_idx ON public.resviz (data_date DESC) INCLUDE (value);
 
 
 --
--- Name: resviz_geom_geom_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: resviz_geom_loc_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX resviz_geom_geom_idx ON public.resviz USING gist (geom);
+CREATE INDEX resviz_geom_loc_idx ON public.resviz USING gist (geom);
 
 
 --

--- a/pygeoapi-deployment/Dockerfile
+++ b/pygeoapi-deployment/Dockerfile
@@ -8,10 +8,18 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
 # this is since we are not using buildkit and thus cannot cache to a mount dir on the host
 ENV UV_LINK_MODE=copy UV_PYTHON_DOWNLOADS=0 UV_NO_CACHE=true
 
+ARG DEB_PACKAGES="\
+    gdal-bin \
+    libgdal-dev \
+    git \
+    build-essential \
+    cron"
+
 WORKDIR /opt/pygeoapi
 
 # System dependencies for GDAL and others
-RUN apt-get update && apt-get install -y --no-install-recommends gdal-bin libgdal-dev git build-essential cron \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ${DEB_PACKAGES} \
     && apt-get clean && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 

--- a/pygeoapi-deployment/pygeoapi.config.yml
+++ b/pygeoapi-deployment/pygeoapi.config.yml
@@ -443,62 +443,33 @@ resources:
     title: Reservoir drought conditions
     description: USBR Reservoir drought conditions
     keywords:
-      - temperature
-      - precipitation
+      - reservoir
+      - drought
     extents:
       spatial:
-        bbox: [-124.76, 41.13, -109.74, 48.99]
+        bbox: [-123.60518, 28.4667, -95.875, 48.8283]
         crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     links:
       - <<: *default-link
         title: information
-        href: https://cida.usgs.gov/thredds/catalog.html?dataset=cida.usgs.gov/prism_v2
     providers:
-      - type: feature
-        name: PostgreSQL
+      - type: edr
+        name: pg_edr.edr.PostgresEDRProvider
         data: &postgres-data
           host: ${POSTGRES_HOST:-localhost}
           dbname: ${POSTGRES_DB:-edr}
           user: ${POSTGRES_USER:-postgres}
           password: ${POSTGRES_PASSWORD:-password}
         table: resviz
+        properties: [max_capacity]
+        edr_fields: # Required EDR Fields
+          id_field: ogc_fid
+          geom_field: geom
+          time_field: data_date
+      - type: feature
+        name: PostgreSQL
+        data: *postgres-data
+        table: resviz
         id_field: ogc_fid
         title_field: site_name
         geom_field: geom
-      - type: edr
-        name: pg_edr.edr.PostgresEDRProvider
-        data: *postgres-data
-        table: resviz
-
-        edr_fields: # Required EDR Fields
-          id_field: ogc_fid # Result identifier field
-          geom_field: geom # Result identifier field
-          time_field: data_date # Result time field
-
-
-  # noaa-nwm:
-  #   type: collection
-  #   title: NOAA National Water Model CONUS Retrospective Dataset
-  #   description: NOAA National Water Model CONUS Retrospective Dataset
-  #   keywords:
-  #     - national water model
-  #     - agriculture
-  #   extents:
-  #     spatial:
-  #       bbox: [-125.020836, 24.104166, -66.520836, 49.9375]
-  #       crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
-  #   links:
-  #     - <<: *default-link
-  #       href: https://registry.opendata.aws/nwm-archive/
-  #   providers:
-  #     - type: edr
-  #       name: xarray-edr
-  #       data: s3://noaa-nwm-retrospective-3-0-pds/CONUS/zarr/chrtout.zarr
-  #       x_field: longitude
-  #       y_field: latitude
-  #       format:
-  #         name: zarr
-  #         mimetype: application/zip
-  #       options:
-  #         s3:
-  #           anon: true

--- a/uv.lock
+++ b/uv.lock
@@ -561,6 +561,12 @@ wheels = [
 ]
 
 [[package]]
+name = "gdal"
+version = "3.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/45/ce25a03268e6ccab9396acb92537b58eb5d0f4bdfa2144fd0f0e3bfdbacc/GDAL-3.6.4.tar.gz", hash = "sha256:c07d548cbd6544e8a51651fc1e487ca4b39e8fe6b5b3c886082d87f0e49e8313", size = 758072, upload-time = "2023-04-21T13:04:05.772Z" }
+
+[[package]]
 name = "geoalchemy2"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1309,7 +1315,7 @@ wheels = [
 [[package]]
 name = "pg-edr"
 version = "0.1.0"
-source = { git = "https://github.com/internetofwater/pgedr.git?rev=main#d12acadb966c929f562bf55760936c6fe8840332" }
+source = { git = "https://github.com/internetofwater/pgedr.git?rev=main#2d7410a12d9545bf034ece079f081a9219931037" }
 dependencies = [
     { name = "cryptography" },
     { name = "geoalchemy2" },
@@ -1831,6 +1837,7 @@ name = "resviz"
 version = "0.1.0"
 source = { editable = "packages/resviz" }
 dependencies = [
+    { name = "gdal" },
     { name = "geoalchemy2" },
     { name = "pg-edr" },
     { name = "psycopg2" },
@@ -1838,6 +1845,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "gdal", specifier = "==3.6.4" },
     { name = "geoalchemy2", specifier = ">=0.17.1" },
     { name = "pg-edr", git = "https://github.com/internetofwater/pgedr.git?rev=main" },
     { name = "psycopg2", specifier = ">=2.9.10" },


### PR DESCRIPTION
Switch to use native GDAL python bindings. This makes it a lot easier to upsert multiple rows in the database per one row in the CSV. At the moment we are only including the recorded value and the 30 year average.