### PR TITLE
add huc06/basin from resviz output

### DIFF
--- a/packages/resviz/resviz/lib.py
+++ b/packages/resviz/resviz/lib.py
@@ -2,12 +2,15 @@
 # SPDX-License-Identifier: MIT
 
 from datetime import timedelta, date
+import logging
 from osgeo import ogr, gdal
 import re
 import requests
 from typing import Iterator
 
 gdal.UseExceptions()
+
+LOGGER = logging.getLogger(__name__)
 
 
 def file_exists(url: str) -> bool:
@@ -25,7 +28,7 @@ def date_range(start_date: date, end_date: date) -> Iterator[date]:
         yield start_date + timedelta(n)
 
 
-def create_feature(pg_layer, row, parameter):
+def create_feature(pg_layer, row, parameter: str):
     """Create postgres feature from a CSV row"""
     p_name = "Lake/Reservoir Storage"
 
@@ -68,7 +71,7 @@ def create_feature(pg_layer, row, parameter):
 
     try:
         pg_layer.CreateFeature(feature)
-    except RuntimeError:
-        pass
+    except RuntimeError as e:
+        LOGGER.error(e)
     finally:
         feature = None  # Release feature

--- a/packages/resviz/resviz/lib.py
+++ b/packages/resviz/resviz/lib.py
@@ -58,6 +58,8 @@ def create_feature(pg_layer, row, parameter: str):
     feature.SetField("site_name", row["SiteName"])
     feature.SetField("state", row["State"])
     feature.SetField("doi_region", row["DoiRegion"])
+    feature.SetField("huc08", row["Huc8"])
+    feature.SetField("huc06", row["Huc8"][:6])
     feature.SetField("value", row[p_val])
     feature.SetField("max_capacity", row["MaxCapacity"])
     feature.SetField("parameter_unit", row["DataUnits"].lower())

--- a/packages/resviz/schema.sql
+++ b/packages/resviz/schema.sql
@@ -117,6 +117,8 @@ CREATE TABLE public.resviz (
     monitoring_location_id character varying,
     site_name character varying,
     state character varying,
+    huc08 integer,
+    huc06 integer,
     doi_region character varying,
     value double precision,
     max_capacity integer,

--- a/packages/usace/docs/mappings.md
+++ b/packages/usace/docs/mappings.md
@@ -19,12 +19,14 @@ There appear to be two publicly available USACE APIs for water data:
 
    2. Each of the locations has:
       - an associated office like (office is the same as provider in the API ontology, confusingly)
+
       ```
       "type":"Feature",
           "properties":{
               "provider":"SAM",
       ```
       - associated timeseries IDs like `RIS.Elev-Forebay.Ave.~1Day.1Day.CBT-REV` that describe the timeseries data and sometimes also the associated units
+
    3. You can then use both the office and the timeseries id to fetch the data (with the start/end specified) like the following
       ```sh
       curl -X 'GET' \


### PR DESCRIPTION
USBR wants to be able to filter by basin. Since their csv web endpoint has the huc08 for each, you can just subset the huc08 with the first 6 characters and get the huc06. The huc06 is to my understanding equivalent to basin in their use case.

Changed the schema manually; I think this is ok but unclear how the dump is being generated

<img width="1541" height="927" alt="image" src="https://github.com/user-attachments/assets/995329d1-54fb-43f3-95a1-2198e1b624e3" />
