### PR TITLE
Drop NaN results from resviz

### DIFF
--- a/packages/resviz/resviz/__init__.py
+++ b/packages/resviz/resviz/__init__.py
@@ -64,7 +64,9 @@ def run_subprocess(csv_url: str):
         )
 
         if isnan(float(row["DataValue"])):
-            LOGGER.error(f"NaN detected on {row['DataDate']} from {row['SiteShortName']}")
+            LOGGER.error(
+                f"NaN detected on {row['DataDate']} from {row['SiteShortName']}"
+            )
 
         # Upsert data value
         create_feature(pg_layer, row, "raw")

--- a/packages/resviz/resviz/__init__.py
+++ b/packages/resviz/resviz/__init__.py
@@ -5,7 +5,7 @@
 import click
 from datetime import date, timedelta, datetime
 from dateutil.parser import parse as dateparse
-from numpy import isnan
+from math import isnan
 
 import logging
 import multiprocessing as mp

--- a/packages/resviz/resviz/__init__.py
+++ b/packages/resviz/resviz/__init__.py
@@ -65,7 +65,7 @@ def run_subprocess(csv_url: str):
 
         if isnan(float(row["DataValue"])):
             LOGGER.error(
-                f"NaN detected on {row['DataDate']} from {row['SiteShortName']}"
+                f"Skipping NaN on {row['DataDate']} from {row['SiteName']}"
             )
 
         # Upsert data value

--- a/packages/resviz/resviz/__init__.py
+++ b/packages/resviz/resviz/__init__.py
@@ -5,6 +5,7 @@
 import click
 from datetime import date, timedelta, datetime
 from dateutil.parser import parse as dateparse
+from numpy import isnan
 
 import logging
 import multiprocessing as mp
@@ -61,6 +62,9 @@ def run_subprocess(csv_url: str):
         row["DataDate"] = datetime.strptime(row["DataDate"], "%m/%d/%Y").strftime(
             "%Y-%m-%d"
         )
+
+        if isnan(float(row["DataValue"])):
+            LOGGER.error(f"NaN detected on {row['DataDate']} from {row['SiteShortName']}")
 
         # Upsert data value
         create_feature(pg_layer, row, "raw")

--- a/packages/resviz/resviz/__init__.py
+++ b/packages/resviz/resviz/__init__.py
@@ -64,9 +64,7 @@ def run_subprocess(csv_url: str):
         )
 
         if isnan(float(row["DataValue"])):
-            LOGGER.error(
-                f"Skipping NaN on {row['DataDate']} from {row['SiteName']}"
-            )
+            LOGGER.error(f"Skipping NaN on {row['DataDate']} from {row['SiteName']}")
 
         # Upsert data value
         create_feature(pg_layer, row, "raw")


### PR DESCRIPTION
Drop NaN values in resviz crawl. This will simply drop any rows that have a NaN value. 