### PR TITLE
Better dataset links for provenance

### DIFF
--- a/pygeoapi-deployment/pygeoapi.config.yml
+++ b/pygeoapi-deployment/pygeoapi.config.yml
@@ -146,6 +146,9 @@ resources:
         name: awdb_forecasts.awdb_forecasts.AwdbForecastsProvider
         data: https://wcc.sc.egov.usda.gov/awdbRestApi/v3/api-docs
         title_field: name
+    links:
+      - <<: *default-link
+        href: https://www.nrcs.usda.gov/wps/portal/wcc/home/aboutUs/monitoringPrograms/automatedSnowMonitoring
 
   snotel-huc06-means:
     type: collection
@@ -177,6 +180,9 @@ resources:
         data: https://wcc.sc.egov.usda.gov/awdbRestApi/v3/api-docs
         entity: Observation
         title_field: name
+    links:
+      - <<: *default-link
+        href: https://water.sec.usace.army.mil/cda/reporting/providers/projects?fmt=geojson
 
   noaa-qpf-day-1: &default-qpf
     type: collection
@@ -486,7 +492,7 @@ resources:
         crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     links:
       - <<: *default-link
-        title: information
+        href: https://data.usbr.gov/rise/rise-resviz/data
     providers:
       - type: edr
         name: pg_edr.edr.PostgresEDRProvider


### PR DESCRIPTION
Add a href for all edr provides in the pygeoapi config, this way I can generate an automated csv for andrew that summarizes all the parameters with their source