### PR TITLE
Feature: geography filter with map and global state integration

### DIFF
--- a/hub-ui/src/features/Map/consts.ts
+++ b/hub-ui/src/features/Map/consts.ts
@@ -3,32 +3,36 @@
  * SPDX-License-Identifier: MIT
  */
 
+import { SourceId } from './sources';
+
 /**
  *
  * @constant
  */
 export const RegionsSource =
-  "https://services1.arcgis.com/fBc8EJBxQRMcHlei/arcgis/rest/services/DOI_Unified_Regions/FeatureServer/0";
+  'https://services1.arcgis.com/fBc8EJBxQRMcHlei/arcgis/rest/services/DOI_Unified_Regions/FeatureServer/0';
 
 /**
  *
  * @constant
  */
 export const ValidStates = [
-  "ND",
-  "SD",
-  "KS",
-  "OK",
-  "TX",
-  "NM",
-  "NE",
-  "CO",
-  "ID",
-  "UT",
-  "NV",
-  "AZ",
-  "MT",
-  "CA",
-  "OR",
-  "WA",
+  'ND',
+  'SD',
+  'KS',
+  'OK',
+  'TX',
+  'NM',
+  'NE',
+  'CO',
+  'ID',
+  'UT',
+  'NV',
+  'AZ',
+  'MT',
+  'CA',
+  'OR',
+  'WA',
 ];
+
+export const GeographyFilterSources = [SourceId.DoiRegions, SourceId.Huc02, SourceId.States];

--- a/hub-ui/src/features/Map/consts.ts
+++ b/hub-ui/src/features/Map/consts.ts
@@ -3,36 +3,40 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { SourceId } from './sources';
+import { SourceId } from "./sources";
 
 /**
  *
  * @constant
  */
 export const RegionsSource =
-  'https://services1.arcgis.com/fBc8EJBxQRMcHlei/arcgis/rest/services/DOI_Unified_Regions/FeatureServer/0';
+  "https://services1.arcgis.com/fBc8EJBxQRMcHlei/arcgis/rest/services/DOI_Unified_Regions/FeatureServer/0";
 
 /**
  *
  * @constant
  */
 export const ValidStates = [
-  'ND',
-  'SD',
-  'KS',
-  'OK',
-  'TX',
-  'NM',
-  'NE',
-  'CO',
-  'ID',
-  'UT',
-  'NV',
-  'AZ',
-  'MT',
-  'CA',
-  'OR',
-  'WA',
+  "ND",
+  "SD",
+  "KS",
+  "OK",
+  "TX",
+  "NM",
+  "NE",
+  "CO",
+  "ID",
+  "UT",
+  "NV",
+  "AZ",
+  "MT",
+  "CA",
+  "OR",
+  "WA",
 ];
 
-export const GeographyFilterSources = [SourceId.DoiRegions, SourceId.Huc02, SourceId.States];
+export const GeographyFilterSources = [
+  SourceId.DoiRegions,
+  SourceId.Huc02,
+  SourceId.States,
+];

--- a/hub-ui/src/features/Map/sources.ts
+++ b/hub-ui/src/features/Map/sources.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SourceConfig } from "@/components/Map/types";
+import { SourceConfig } from '@/components/Map/types';
 
 export enum SourceId {
-  Huc02 = "hu02",
-  States = "states",
+  Huc02 = 'hu02',
+  States = 'states',
+  DoiRegions = 'doi-regions',
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/hub-ui/src/features/Map/sources.ts
+++ b/hub-ui/src/features/Map/sources.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SourceConfig } from '@/components/Map/types';
+import { SourceConfig } from "@/components/Map/types";
 
 export enum SourceId {
-  Huc02 = 'hu02',
-  States = 'states',
-  DoiRegions = 'doi-regions',
+  Huc02 = "hu02",
+  States = "states",
+  DoiRegions = "doi-regions",
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/hub-ui/src/features/Map/utils.ts
+++ b/hub-ui/src/features/Map/utils.ts
@@ -3,28 +3,46 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ExpressionSpecification, LayerSpecification } from "mapbox-gl";
-import { Location } from "@/stores/main/types";
+import { ExpressionSpecification, LayerSpecification } from 'mapbox-gl';
+import { LayerType } from '@/components/Map/types';
+import { Location } from '@/stores/main/types';
 
-export const getPointLayerDefinition = (
-  layerId: string,
-  sourceId: string,
-): LayerSpecification => {
+export const getPointLayerDefinition = (layerId: string, sourceId: string): LayerSpecification => {
   return {
     id: layerId,
     source: sourceId,
-    type: "circle",
+    type: LayerType.Circle,
     paint: {
-      "circle-radius": 6,
-      "circle-color": "#B42222",
-      "circle-stroke-width": 2,
-      "circle-stroke-color": getCircleStrokeColor([]),
+      'circle-radius': 6,
+      'circle-color': '#B42222',
+      'circle-stroke-width': 2,
+      'circle-stroke-color': getCircleStrokeColor([]),
+    },
+  };
+};
+
+export const getPolygonLayerDefinition = (
+  layerId: string,
+  sourceId: string
+): LayerSpecification => {
+  return {
+    id: layerId,
+    type: LayerType.Line,
+    source: sourceId,
+    layout: {
+      'line-cap': 'round',
+      'line-join': 'round',
+    },
+    paint: {
+      'line-opacity': 1,
+      'line-color': '#000',
+      'line-width': 2,
     },
   };
 };
 
 export const getCircleStrokeColor = (
-  locationIds: Array<Location["id"]>,
+  locationIds: Array<Location['id']>
 ): ExpressionSpecification => {
-  return ["case", ["in", ["id"], ["literal", locationIds]], "#FFF", "#000"];
+  return ['case', ['in', ['id'], ['literal', locationIds]], '#FFF', '#000'];
 };

--- a/hub-ui/src/features/Map/utils.ts
+++ b/hub-ui/src/features/Map/utils.ts
@@ -3,46 +3,49 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ExpressionSpecification, LayerSpecification } from 'mapbox-gl';
-import { LayerType } from '@/components/Map/types';
-import { Location } from '@/stores/main/types';
+import { ExpressionSpecification, LayerSpecification } from "mapbox-gl";
+import { LayerType } from "@/components/Map/types";
+import { Location } from "@/stores/main/types";
 
-export const getPointLayerDefinition = (layerId: string, sourceId: string): LayerSpecification => {
+export const getPointLayerDefinition = (
+  layerId: string,
+  sourceId: string,
+): LayerSpecification => {
   return {
     id: layerId,
     source: sourceId,
     type: LayerType.Circle,
     paint: {
-      'circle-radius': 6,
-      'circle-color': '#B42222',
-      'circle-stroke-width': 2,
-      'circle-stroke-color': getCircleStrokeColor([]),
+      "circle-radius": 6,
+      "circle-color": "#B42222",
+      "circle-stroke-width": 2,
+      "circle-stroke-color": getCircleStrokeColor([]),
     },
   };
 };
 
 export const getPolygonLayerDefinition = (
   layerId: string,
-  sourceId: string
+  sourceId: string,
 ): LayerSpecification => {
   return {
     id: layerId,
     type: LayerType.Line,
     source: sourceId,
     layout: {
-      'line-cap': 'round',
-      'line-join': 'round',
+      "line-cap": "round",
+      "line-join": "round",
     },
     paint: {
-      'line-opacity': 1,
-      'line-color': '#000',
-      'line-width': 2,
+      "line-opacity": 1,
+      "line-color": "#000",
+      "line-width": 2,
     },
   };
 };
 
 export const getCircleStrokeColor = (
-  locationIds: Array<Location['id']>
+  locationIds: Array<Location["id"]>,
 ): ExpressionSpecification => {
-  return ['case', ['in', ['id'], ['literal', locationIds]], '#FFF', '#000'];
+  return ["case", ["in", ["id"], ["literal", locationIds]], "#FFF", "#000"];
 };

--- a/hub-ui/src/features/Panel/Filters/Location/Basin.tsx
+++ b/hub-ui/src/features/Panel/Filters/Location/Basin.tsx
@@ -3,22 +3,31 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { useEffect, useRef, useState } from "react";
-import { FeatureCollection, Polygon } from "geojson";
-import { ComboboxData, Select, Skeleton } from "@mantine/core";
-import { SourceId } from "@/features/Map/sources";
-import geoconnexService from "@/services/init/geoconnex.init";
-import { Huc02BasinProperties, Huc02Field } from "@/types/huc02";
-import { formatOptions } from "../utils";
+import { useEffect, useRef, useState } from 'react';
+import { FeatureCollection, Polygon } from 'geojson';
+import { ComboboxData, Select, Skeleton } from '@mantine/core';
+import { SourceId } from '@/features/Map/sources';
+import loadingManager from '@/managers/Loading.init';
+import mainManager from '@/managers/Main.init';
+import notificationManager from '@/managers/Notification.init';
+import geoconnexService from '@/services/init/geoconnex.init';
+import useMainStore from '@/stores/main';
+import { NotificationType } from '@/stores/session/types';
+import { Huc02BasinProperties, Huc02Field } from '@/types/huc02';
+import { formatOptions } from '../utils';
 
 export const Basin: React.FC = () => {
-  const [loading, setLoading] = useState(true);
+  const geographyFilterCollectionId = useMainStore((state) => state.geographyFilter?.collectionId);
+  const geographyFilterItemId = useMainStore((state) => state.geographyFilter?.itemId);
+
   const [basinOptions, setBasinOptions] = useState<ComboboxData>([]);
 
   const controller = useRef<AbortController>(null);
   const isMounted = useRef(true);
 
   const getBasinOptions = async () => {
+    const loadingInstance = loadingManager.add('Fetching basin dropdown options');
+
     try {
       controller.current = new AbortController();
 
@@ -35,24 +44,25 @@ export const Basin: React.FC = () => {
         const basinOptions = formatOptions(
           basinFeatureCollection.features,
           (feature) => String(feature.id),
-          (feature) => String(feature?.properties?.[Huc02Field.Name]),
+          (feature) => String(feature?.properties?.[Huc02Field.Name])
         );
 
         if (isMounted.current) {
-          setLoading(false);
+          loadingManager.remove(loadingInstance);
           setBasinOptions(basinOptions);
         }
       }
     } catch (error) {
       if (
-        (error as Error)?.name === "AbortError" ||
-        (typeof error === "string" && error === "Component unmount")
+        (error as Error)?.name === 'AbortError' ||
+        (typeof error === 'string' && error === 'Component unmount')
       ) {
-        console.log("Fetch request canceled");
+        console.log('Fetch request canceled');
       } else if ((error as Error)?.message) {
         const _error = error as Error;
-        console.error(_error);
+        notificationManager.show(`Error: ${_error.message}`, NotificationType.Error);
       }
+      loadingManager.remove(loadingInstance);
     }
   };
 
@@ -62,22 +72,44 @@ export const Basin: React.FC = () => {
     return () => {
       isMounted.current = false;
       if (controller.current) {
-        controller.current.abort("Component unmount");
+        controller.current.abort('Component unmount');
       }
     };
   }, []);
 
+  const handleChange = async (itemId: string | null) => {
+    if (itemId) {
+      const loadingInstance = loadingManager.add('Adding basin geography filter');
+      await mainManager.updateGeographyFilter(SourceId.Huc02, itemId);
+      loadingManager.remove(loadingInstance);
+      notificationManager.show('Updated geography filter', NotificationType.Success);
+    }
+  };
+
+  const handleClear = () => {
+    mainManager.removeGeographyFilter();
+  };
+
   return (
     <Skeleton
       height={55} // Default dimensions of select
-      visible={loading || basinOptions.length === 0}
+      visible={basinOptions.length === 0}
     >
       <Select
+        key={`basin-select-${geographyFilterCollectionId}`}
         size="xs"
         label="Basin"
         placeholder="Select..."
         data={basinOptions}
+        value={
+          geographyFilterCollectionId === SourceId.Huc02 && geographyFilterItemId
+            ? geographyFilterItemId
+            : undefined
+        }
+        onChange={(value) => handleChange(value)}
+        onClear={() => handleClear()}
         searchable
+        clearable
       />
     </Skeleton>
   );

--- a/hub-ui/src/features/Panel/Filters/Location/Basin.tsx
+++ b/hub-ui/src/features/Panel/Filters/Location/Basin.tsx
@@ -3,22 +3,26 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { useEffect, useRef, useState } from 'react';
-import { FeatureCollection, Polygon } from 'geojson';
-import { ComboboxData, Select, Skeleton } from '@mantine/core';
-import { SourceId } from '@/features/Map/sources';
-import loadingManager from '@/managers/Loading.init';
-import mainManager from '@/managers/Main.init';
-import notificationManager from '@/managers/Notification.init';
-import geoconnexService from '@/services/init/geoconnex.init';
-import useMainStore from '@/stores/main';
-import { NotificationType } from '@/stores/session/types';
-import { Huc02BasinProperties, Huc02Field } from '@/types/huc02';
-import { formatOptions } from '../utils';
+import { useEffect, useRef, useState } from "react";
+import { FeatureCollection, Polygon } from "geojson";
+import { ComboboxData, Select, Skeleton } from "@mantine/core";
+import { SourceId } from "@/features/Map/sources";
+import loadingManager from "@/managers/Loading.init";
+import mainManager from "@/managers/Main.init";
+import notificationManager from "@/managers/Notification.init";
+import geoconnexService from "@/services/init/geoconnex.init";
+import useMainStore from "@/stores/main";
+import { NotificationType } from "@/stores/session/types";
+import { Huc02BasinProperties, Huc02Field } from "@/types/huc02";
+import { formatOptions } from "../utils";
 
 export const Basin: React.FC = () => {
-  const geographyFilterCollectionId = useMainStore((state) => state.geographyFilter?.collectionId);
-  const geographyFilterItemId = useMainStore((state) => state.geographyFilter?.itemId);
+  const geographyFilterCollectionId = useMainStore(
+    (state) => state.geographyFilter?.collectionId,
+  );
+  const geographyFilterItemId = useMainStore(
+    (state) => state.geographyFilter?.itemId,
+  );
 
   const [basinOptions, setBasinOptions] = useState<ComboboxData>([]);
 
@@ -26,7 +30,9 @@ export const Basin: React.FC = () => {
   const isMounted = useRef(true);
 
   const getBasinOptions = async () => {
-    const loadingInstance = loadingManager.add('Fetching basin dropdown options');
+    const loadingInstance = loadingManager.add(
+      "Fetching basin dropdown options",
+    );
 
     try {
       controller.current = new AbortController();
@@ -44,7 +50,7 @@ export const Basin: React.FC = () => {
         const basinOptions = formatOptions(
           basinFeatureCollection.features,
           (feature) => String(feature.id),
-          (feature) => String(feature?.properties?.[Huc02Field.Name])
+          (feature) => String(feature?.properties?.[Huc02Field.Name]),
         );
 
         if (isMounted.current) {
@@ -54,13 +60,16 @@ export const Basin: React.FC = () => {
       }
     } catch (error) {
       if (
-        (error as Error)?.name === 'AbortError' ||
-        (typeof error === 'string' && error === 'Component unmount')
+        (error as Error)?.name === "AbortError" ||
+        (typeof error === "string" && error === "Component unmount")
       ) {
-        console.log('Fetch request canceled');
+        console.log("Fetch request canceled");
       } else if ((error as Error)?.message) {
         const _error = error as Error;
-        notificationManager.show(`Error: ${_error.message}`, NotificationType.Error);
+        notificationManager.show(
+          `Error: ${_error.message}`,
+          NotificationType.Error,
+        );
       }
       loadingManager.remove(loadingInstance);
     }
@@ -72,17 +81,22 @@ export const Basin: React.FC = () => {
     return () => {
       isMounted.current = false;
       if (controller.current) {
-        controller.current.abort('Component unmount');
+        controller.current.abort("Component unmount");
       }
     };
   }, []);
 
   const handleChange = async (itemId: string | null) => {
     if (itemId) {
-      const loadingInstance = loadingManager.add('Adding basin geography filter');
+      const loadingInstance = loadingManager.add(
+        "Adding basin geography filter",
+      );
       await mainManager.updateGeographyFilter(SourceId.Huc02, itemId);
       loadingManager.remove(loadingInstance);
-      notificationManager.show('Updated geography filter', NotificationType.Success);
+      notificationManager.show(
+        "Updated geography filter",
+        NotificationType.Success,
+      );
     }
   };
 
@@ -102,7 +116,8 @@ export const Basin: React.FC = () => {
         placeholder="Select..."
         data={basinOptions}
         value={
-          geographyFilterCollectionId === SourceId.Huc02 && geographyFilterItemId
+          geographyFilterCollectionId === SourceId.Huc02 &&
+          geographyFilterItemId
             ? geographyFilterItemId
             : undefined
         }

--- a/hub-ui/src/features/Panel/Filters/Location/Region.tsx
+++ b/hub-ui/src/features/Panel/Filters/Location/Region.tsx
@@ -3,22 +3,26 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { useEffect, useRef, useState } from 'react';
-import { FeatureCollection, Polygon } from 'geojson';
-import { ComboboxData, Select, Skeleton } from '@mantine/core';
-import { SourceId } from '@/features/Map/sources';
-import loadingManager from '@/managers/Loading.init';
-import mainManager from '@/managers/Main.init';
-import notificationManager from '@/managers/Notification.init';
-import wwdhService from '@/services/init/wwdh.init';
-import useMainStore from '@/stores/main';
-import { NotificationType } from '@/stores/session/types';
-import { RegionField, RegionProperties } from '@/types/region';
-import { formatOptions } from '../utils';
+import { useEffect, useRef, useState } from "react";
+import { FeatureCollection, Polygon } from "geojson";
+import { ComboboxData, Select, Skeleton } from "@mantine/core";
+import { SourceId } from "@/features/Map/sources";
+import loadingManager from "@/managers/Loading.init";
+import mainManager from "@/managers/Main.init";
+import notificationManager from "@/managers/Notification.init";
+import wwdhService from "@/services/init/wwdh.init";
+import useMainStore from "@/stores/main";
+import { NotificationType } from "@/stores/session/types";
+import { RegionField, RegionProperties } from "@/types/region";
+import { formatOptions } from "../utils";
 
 export const Region: React.FC = () => {
-  const geographyFilterCollectionId = useMainStore((state) => state.geographyFilter?.collectionId);
-  const geographyFilterItemId = useMainStore((state) => state.geographyFilter?.itemId);
+  const geographyFilterCollectionId = useMainStore(
+    (state) => state.geographyFilter?.collectionId,
+  );
+  const geographyFilterItemId = useMainStore(
+    (state) => state.geographyFilter?.itemId,
+  );
 
   const [regionOptions, setRegionOptions] = useState<ComboboxData>([]);
 
@@ -26,7 +30,9 @@ export const Region: React.FC = () => {
   const isMounted = useRef(true);
 
   const getRegionOptions = async () => {
-    const loadingInstance = loadingManager.add('Fetching region dropdown options');
+    const loadingInstance = loadingManager.add(
+      "Fetching region dropdown options",
+    );
 
     try {
       controller.current = new AbortController();
@@ -44,7 +50,7 @@ export const Region: React.FC = () => {
         const basinOptions = formatOptions(
           regionFeatureCollection.features,
           (feature) => String(feature.id),
-          (feature) => String(feature?.properties?.[RegionField.Name])
+          (feature) => String(feature?.properties?.[RegionField.Name]),
         );
 
         if (isMounted.current) {
@@ -54,13 +60,16 @@ export const Region: React.FC = () => {
       }
     } catch (error) {
       if (
-        (error as Error)?.name === 'AbortError' ||
-        (typeof error === 'string' && error === 'Component unmount')
+        (error as Error)?.name === "AbortError" ||
+        (typeof error === "string" && error === "Component unmount")
       ) {
-        console.log('Fetch request canceled');
+        console.log("Fetch request canceled");
       } else if ((error as Error)?.message) {
         const _error = error as Error;
-        notificationManager.show(`Error: ${_error.message}`, NotificationType.Error);
+        notificationManager.show(
+          `Error: ${_error.message}`,
+          NotificationType.Error,
+        );
       }
       loadingManager.remove(loadingInstance);
     }
@@ -71,17 +80,22 @@ export const Region: React.FC = () => {
     return () => {
       isMounted.current = false;
       if (controller.current) {
-        controller.current.abort('Component unmount');
+        controller.current.abort("Component unmount");
       }
     };
   }, []);
 
   const handleChange = async (itemId: string | null) => {
     if (itemId) {
-      const loadingInstance = loadingManager.add('Adding region geography filter');
+      const loadingInstance = loadingManager.add(
+        "Adding region geography filter",
+      );
       await mainManager.updateGeographyFilter(SourceId.DoiRegions, itemId);
       loadingManager.remove(loadingInstance);
-      notificationManager.show('Updated geography filter', NotificationType.Success);
+      notificationManager.show(
+        "Updated geography filter",
+        NotificationType.Success,
+      );
     }
   };
 
@@ -101,7 +115,8 @@ export const Region: React.FC = () => {
         placeholder="Select..."
         data={regionOptions}
         value={
-          geographyFilterCollectionId === SourceId.DoiRegions && geographyFilterItemId
+          geographyFilterCollectionId === SourceId.DoiRegions &&
+          geographyFilterItemId
             ? geographyFilterItemId
             : undefined
         }

--- a/hub-ui/src/features/Panel/Filters/Location/Region.tsx
+++ b/hub-ui/src/features/Panel/Filters/Location/Region.tsx
@@ -3,73 +3,112 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { useEffect, useRef, useState } from "react";
-import { ComboboxData, Select, Skeleton } from "@mantine/core";
-import esriService from "@/services/init/esri.init";
-import { RegionField } from "@/types/region";
-import { formatOptions } from "../utils";
+import { useEffect, useRef, useState } from 'react';
+import { FeatureCollection, Polygon } from 'geojson';
+import { ComboboxData, Select, Skeleton } from '@mantine/core';
+import { SourceId } from '@/features/Map/sources';
+import loadingManager from '@/managers/Loading.init';
+import mainManager from '@/managers/Main.init';
+import notificationManager from '@/managers/Notification.init';
+import wwdhService from '@/services/init/wwdh.init';
+import useMainStore from '@/stores/main';
+import { NotificationType } from '@/stores/session/types';
+import { RegionField, RegionProperties } from '@/types/region';
+import { formatOptions } from '../utils';
 
 export const Region: React.FC = () => {
+  const geographyFilterCollectionId = useMainStore((state) => state.geographyFilter?.collectionId);
+  const geographyFilterItemId = useMainStore((state) => state.geographyFilter?.itemId);
+
   const [regionOptions, setRegionOptions] = useState<ComboboxData>([]);
-  const [loading, setLoading] = useState(true);
 
   const controller = useRef<AbortController>(null);
   const isMounted = useRef(true);
+
   const getRegionOptions = async () => {
+    const loadingInstance = loadingManager.add('Fetching region dropdown options');
+
     try {
       controller.current = new AbortController();
 
-      const regionFeatureCollection = await esriService.getFeatures(
-        controller.current.signal,
-      );
+      const regionFeatureCollection = await wwdhService.getItems<
+        FeatureCollection<Polygon, RegionProperties>
+      >(SourceId.DoiRegions, {
+        params: {
+          bbox: [-125, 24, -96.5, 49],
+          skipGeometry: true,
+        },
+      });
 
       if (regionFeatureCollection.features.length) {
-        const regionOptions = formatOptions(
+        const basinOptions = formatOptions(
           regionFeatureCollection.features,
-          (feature) => String(feature?.properties?.[RegionField.Name]),
-          (feature) => String(feature?.properties?.[RegionField.Name]),
+          (feature) => String(feature.id),
+          (feature) => String(feature?.properties?.[RegionField.Name])
         );
 
         if (isMounted.current) {
-          setLoading(false);
-          setRegionOptions(regionOptions);
+          loadingManager.remove(loadingInstance);
+          setRegionOptions(basinOptions);
         }
       }
     } catch (error) {
       if (
-        (error as Error)?.name === "AbortError" ||
-        (typeof error === "string" && error === "Component unmount")
+        (error as Error)?.name === 'AbortError' ||
+        (typeof error === 'string' && error === 'Component unmount')
       ) {
-        console.log("Fetch request canceled");
+        console.log('Fetch request canceled');
       } else if ((error as Error)?.message) {
         const _error = error as Error;
-        console.error(_error);
+        notificationManager.show(`Error: ${_error.message}`, NotificationType.Error);
       }
+      loadingManager.remove(loadingInstance);
     }
   };
-
   useEffect(() => {
     isMounted.current = true;
     void getRegionOptions();
     return () => {
       isMounted.current = false;
       if (controller.current) {
-        controller.current.abort("Component unmount");
+        controller.current.abort('Component unmount');
       }
     };
   }, []);
 
+  const handleChange = async (itemId: string | null) => {
+    if (itemId) {
+      const loadingInstance = loadingManager.add('Adding region geography filter');
+      await mainManager.updateGeographyFilter(SourceId.DoiRegions, itemId);
+      loadingManager.remove(loadingInstance);
+      notificationManager.show('Updated geography filter', NotificationType.Success);
+    }
+  };
+
+  const handleClear = () => {
+    mainManager.removeGeographyFilter();
+  };
+
   return (
     <Skeleton
       height={55} // Default dimensions of select
-      visible={loading || regionOptions.length === 0}
+      visible={regionOptions.length === 0}
     >
       <Select
+        key={`region-select-${geographyFilterCollectionId}`}
         size="xs"
         label="Region"
         placeholder="Select..."
         data={regionOptions}
+        value={
+          geographyFilterCollectionId === SourceId.DoiRegions && geographyFilterItemId
+            ? geographyFilterItemId
+            : undefined
+        }
+        onChange={(value) => handleChange(value)}
+        onClear={() => handleClear()}
         searchable
+        clearable
       />
     </Skeleton>
   );

--- a/hub-ui/src/features/Panel/Filters/Location/State.tsx
+++ b/hub-ui/src/features/Panel/Filters/Location/State.tsx
@@ -3,23 +3,31 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { useEffect, useRef, useState } from "react";
-import { FeatureCollection, Polygon } from "geojson";
-import { ComboboxData, Select, Skeleton } from "@mantine/core";
-import { ValidStates } from "@/features/Map/consts";
-import { SourceId } from "@/features/Map/sources";
-import geoconnexService from "@/services/init/geoconnex.init";
-import { StateField, StateProperties } from "@/types/state";
-import { formatOptions } from "../utils";
+import { useEffect, useRef, useState } from 'react';
+import { FeatureCollection, Polygon } from 'geojson';
+import { ComboboxData, Select, Skeleton } from '@mantine/core';
+import { ValidStates } from '@/features/Map/consts';
+import { SourceId } from '@/features/Map/sources';
+import loadingManager from '@/managers/Loading.init';
+import mainManager from '@/managers/Main.init';
+import notificationManager from '@/managers/Notification.init';
+import geoconnexService from '@/services/init/geoconnex.init';
+import useMainStore from '@/stores/main';
+import { NotificationType } from '@/stores/session/types';
+import { StateField, StateProperties } from '@/types/state';
+import { formatOptions } from '../utils';
 
 export const State: React.FC = () => {
-  const [loading, setLoading] = useState(true);
+  const geographyFilterCollectionId = useMainStore((state) => state.geographyFilter?.collectionId);
+  const geographyFilterItemId = useMainStore((state) => state.geographyFilter?.itemId);
+
   const [stateOptions, setStateOptions] = useState<ComboboxData>([]);
 
   const controller = useRef<AbortController>(null);
   const isMounted = useRef(true);
 
-  const getBasinOptions = async () => {
+  const getStateOptions = async () => {
+    const loadingInstance = loadingManager.add('Fetching state dropdown options');
     try {
       controller.current = new AbortController();
 
@@ -35,53 +43,76 @@ export const State: React.FC = () => {
       if (stateFeatureCollection.features.length) {
         const basinOptions = formatOptions(
           stateFeatureCollection.features.filter((feature) =>
-            ValidStates.includes(feature.properties[StateField.Acronym]),
+            ValidStates.includes(feature.properties[StateField.Acronym])
           ),
-          (feature) => String(feature?.properties?.[StateField.Acronym]),
+          (feature) => String(feature?.id),
           (feature) => String(feature?.properties?.[StateField.Name]),
-          "All States",
+          'All States'
         );
 
         if (isMounted.current) {
-          setLoading(false);
+          loadingManager.remove(loadingInstance);
           setStateOptions(basinOptions);
         }
       }
     } catch (error) {
       if (
-        (error as Error)?.name === "AbortError" ||
-        (typeof error === "string" && error === "Component unmount")
+        (error as Error)?.name === 'AbortError' ||
+        (typeof error === 'string' && error === 'Component unmount')
       ) {
-        console.log("Fetch request canceled");
+        console.log('Fetch request canceled');
       } else if ((error as Error)?.message) {
         const _error = error as Error;
-        console.error(_error);
+        notificationManager.show(`Error: ${_error.message}`, NotificationType.Error);
       }
+      loadingManager.remove(loadingInstance);
     }
   };
 
   useEffect(() => {
     isMounted.current = true;
-    void getBasinOptions();
+    void getStateOptions();
     return () => {
       isMounted.current = false;
       if (controller.current) {
-        controller.current.abort("Component unmount");
+        controller.current.abort('Component unmount');
       }
     };
   }, []);
 
+  const handleChange = async (itemId: string | null) => {
+    if (itemId) {
+      const loadingInstance = loadingManager.add('Adding state geography filter');
+      await mainManager.updateGeographyFilter(SourceId.States, itemId);
+      loadingManager.remove(loadingInstance);
+      notificationManager.show('Updated geography filter', NotificationType.Success);
+    }
+  };
+
+  const handleClear = () => {
+    mainManager.removeGeographyFilter();
+  };
+
   return (
     <Skeleton
       height={55} // Default dimensions of select
-      visible={loading || stateOptions.length === 0}
+      visible={stateOptions.length === 0}
     >
       <Select
+        key={`state-select-${geographyFilterCollectionId}`}
         size="xs"
         label="State"
         placeholder="Select..."
         data={stateOptions}
+        value={
+          geographyFilterCollectionId === SourceId.States && geographyFilterItemId
+            ? geographyFilterItemId
+            : undefined
+        }
+        onChange={(value) => handleChange(value)}
+        onClear={() => handleClear()}
         searchable
+        clearable
       />
     </Skeleton>
   );

--- a/hub-ui/src/features/Panel/Filters/Location/State.tsx
+++ b/hub-ui/src/features/Panel/Filters/Location/State.tsx
@@ -3,23 +3,27 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { useEffect, useRef, useState } from 'react';
-import { FeatureCollection, Polygon } from 'geojson';
-import { ComboboxData, Select, Skeleton } from '@mantine/core';
-import { ValidStates } from '@/features/Map/consts';
-import { SourceId } from '@/features/Map/sources';
-import loadingManager from '@/managers/Loading.init';
-import mainManager from '@/managers/Main.init';
-import notificationManager from '@/managers/Notification.init';
-import geoconnexService from '@/services/init/geoconnex.init';
-import useMainStore from '@/stores/main';
-import { NotificationType } from '@/stores/session/types';
-import { StateField, StateProperties } from '@/types/state';
-import { formatOptions } from '../utils';
+import { useEffect, useRef, useState } from "react";
+import { FeatureCollection, Polygon } from "geojson";
+import { ComboboxData, Select, Skeleton } from "@mantine/core";
+import { ValidStates } from "@/features/Map/consts";
+import { SourceId } from "@/features/Map/sources";
+import loadingManager from "@/managers/Loading.init";
+import mainManager from "@/managers/Main.init";
+import notificationManager from "@/managers/Notification.init";
+import geoconnexService from "@/services/init/geoconnex.init";
+import useMainStore from "@/stores/main";
+import { NotificationType } from "@/stores/session/types";
+import { StateField, StateProperties } from "@/types/state";
+import { formatOptions } from "../utils";
 
 export const State: React.FC = () => {
-  const geographyFilterCollectionId = useMainStore((state) => state.geographyFilter?.collectionId);
-  const geographyFilterItemId = useMainStore((state) => state.geographyFilter?.itemId);
+  const geographyFilterCollectionId = useMainStore(
+    (state) => state.geographyFilter?.collectionId,
+  );
+  const geographyFilterItemId = useMainStore(
+    (state) => state.geographyFilter?.itemId,
+  );
 
   const [stateOptions, setStateOptions] = useState<ComboboxData>([]);
 
@@ -27,7 +31,9 @@ export const State: React.FC = () => {
   const isMounted = useRef(true);
 
   const getStateOptions = async () => {
-    const loadingInstance = loadingManager.add('Fetching state dropdown options');
+    const loadingInstance = loadingManager.add(
+      "Fetching state dropdown options",
+    );
     try {
       controller.current = new AbortController();
 
@@ -43,11 +49,11 @@ export const State: React.FC = () => {
       if (stateFeatureCollection.features.length) {
         const basinOptions = formatOptions(
           stateFeatureCollection.features.filter((feature) =>
-            ValidStates.includes(feature.properties[StateField.Acronym])
+            ValidStates.includes(feature.properties[StateField.Acronym]),
           ),
           (feature) => String(feature?.id),
           (feature) => String(feature?.properties?.[StateField.Name]),
-          'All States'
+          "All States",
         );
 
         if (isMounted.current) {
@@ -57,13 +63,16 @@ export const State: React.FC = () => {
       }
     } catch (error) {
       if (
-        (error as Error)?.name === 'AbortError' ||
-        (typeof error === 'string' && error === 'Component unmount')
+        (error as Error)?.name === "AbortError" ||
+        (typeof error === "string" && error === "Component unmount")
       ) {
-        console.log('Fetch request canceled');
+        console.log("Fetch request canceled");
       } else if ((error as Error)?.message) {
         const _error = error as Error;
-        notificationManager.show(`Error: ${_error.message}`, NotificationType.Error);
+        notificationManager.show(
+          `Error: ${_error.message}`,
+          NotificationType.Error,
+        );
       }
       loadingManager.remove(loadingInstance);
     }
@@ -75,17 +84,22 @@ export const State: React.FC = () => {
     return () => {
       isMounted.current = false;
       if (controller.current) {
-        controller.current.abort('Component unmount');
+        controller.current.abort("Component unmount");
       }
     };
   }, []);
 
   const handleChange = async (itemId: string | null) => {
     if (itemId) {
-      const loadingInstance = loadingManager.add('Adding state geography filter');
+      const loadingInstance = loadingManager.add(
+        "Adding state geography filter",
+      );
       await mainManager.updateGeographyFilter(SourceId.States, itemId);
       loadingManager.remove(loadingInstance);
-      notificationManager.show('Updated geography filter', NotificationType.Success);
+      notificationManager.show(
+        "Updated geography filter",
+        NotificationType.Success,
+      );
     }
   };
 
@@ -105,7 +119,8 @@ export const State: React.FC = () => {
         placeholder="Select..."
         data={stateOptions}
         value={
-          geographyFilterCollectionId === SourceId.States && geographyFilterItemId
+          geographyFilterCollectionId === SourceId.States &&
+          geographyFilterItemId
             ? geographyFilterItemId
             : undefined
         }

--- a/hub-ui/src/features/Panel/Panel.module.css
+++ b/hub-ui/src/features/Panel/Panel.module.css
@@ -5,7 +5,7 @@
 
 .panelWrapper {
   height: 100%;
-  max-height: 100%;
+  max-height: 99vh;
 
   width: 400px;
   max-width: 25%;

--- a/hub-ui/src/managers/Main.manager.ts
+++ b/hub-ui/src/managers/Main.manager.ts
@@ -3,19 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { FeatureCollection, Point } from "geojson";
-import { Map } from "mapbox-gl";
-import { v6 } from "uuid";
-import { GeoJSONFeature, stringify } from "wellknown";
-import { StoreApi, UseBoundStore } from "zustand";
-import { getPointLayerDefinition } from "@/features/Map/utils";
-import wwdhService from "@/services/init/wwdh.init";
-import {
-  Collection,
-  ColorValueHex,
-  Location,
-  MainState,
-} from "@/stores/main/types";
+import * as turf from '@turf/turf';
+import { Feature, FeatureCollection, Point, Polygon } from 'geojson';
+import { GeoJSONSource, LngLatBoundsLike, Map } from 'mapbox-gl';
+import { v6 } from 'uuid';
+import { GeoJSONFeature, stringify } from 'wellknown';
+import { StoreApi, UseBoundStore } from 'zustand';
+import { GeographyFilterSources } from '@/features/Map/consts';
+import { SourceId } from '@/features/Map/sources';
+import { getPointLayerDefinition, getPolygonLayerDefinition } from '@/features/Map/utils';
+import geoconnexService from '@/services/init/geoconnex.init';
+import wwdhService from '@/services/init/wwdh.init';
+import { Collection, ColorValueHex, Location, MainState } from '@/stores/main/types';
 
 type FakeCollection = {
   id: string;
@@ -65,7 +64,7 @@ class MainManager {
    * @function
    */
   private createHexColor(): ColorValueHex {
-    return "#fake";
+    return '#fake';
   }
 
   /**
@@ -80,7 +79,7 @@ class MainManager {
    *
    * @function
    */
-  public hasCollection(collectionId: Collection["id"]): boolean {
+  public hasCollection(collectionId: Collection['id']): boolean {
     return this.store.getState().hasCollection(collectionId);
   }
 
@@ -88,7 +87,7 @@ class MainManager {
    *
    * @function
    */
-  public hasLocation(locationId: Location["id"]): boolean {
+  public hasLocation(locationId: Location['id']): boolean {
     return this.store.getState().hasLocation(locationId);
   }
 
@@ -96,24 +95,20 @@ class MainManager {
    *
    * @function
    */
-  public async getData(
-    collectionId: Collection["id"],
-  ): Promise<FeatureCollection<Point>> {
+  public async getData(collectionId: Collection['id']): Promise<FeatureCollection<Point>> {
     const geographyFilter = this.store.getState().geographyFilter;
     if (geographyFilter) {
-      const feature = geographyFilter as unknown as GeoJSONFeature;
+      const feature = geographyFilter.feature as unknown as GeoJSONFeature;
       return this.getArea(collectionId, feature);
     }
-    return this.getLocation(collectionId);
+    return this.getLocations(collectionId);
   }
 
   /**
    *
    * @function
    */
-  private async getLocation(
-    collectionId: Collection["id"],
-  ): Promise<FeatureCollection<Point>> {
+  private async getLocations(collectionId: Collection['id']): Promise<FeatureCollection<Point>> {
     return wwdhService.getLocations<FeatureCollection<Point>>(collectionId);
   }
 
@@ -122,13 +117,13 @@ class MainManager {
    * @function
    */
   private async getArea(
-    collectionId: Collection["id"],
-    geographyFilter: GeoJSONFeature,
+    collectionId: Collection['id'],
+    feature: GeoJSONFeature
   ): Promise<FeatureCollection<Point>> {
-    const wkt = stringify(geographyFilter);
+    const wkt = stringify(feature);
 
     return wwdhService.getArea<FeatureCollection<Point>>(collectionId, {
-      method: "POST",
+      method: 'POST',
       params: {
         coords: wkt,
       },
@@ -139,7 +134,7 @@ class MainManager {
    *
    * @function
    */
-  public getSourceId(collectionId: Collection["id"]): string {
+  public getSourceId(collectionId: Collection['id']): string {
     return `${collectionId}-source`;
   }
 
@@ -147,7 +142,7 @@ class MainManager {
    *
    * @function
    */
-  public getLayerId(collectionId: Collection["id"]): string {
+  public getLayerId(collectionId: Collection['id']): string {
     return `${collectionId}-locations`;
   }
 
@@ -155,12 +150,12 @@ class MainManager {
    *
    * @function
    */
-  private async addMapSource(collectionId: Collection["id"]): Promise<string> {
+  private async addMapSource(collectionId: Collection['id']): Promise<string> {
     const sourceId = this.getSourceId(collectionId);
     if (this.map && !this.map.getSource(sourceId)) {
       const data = await this.getData(collectionId);
       this.map.addSource(sourceId, {
-        type: "geojson",
+        type: 'geojson',
         data,
       });
     }
@@ -172,15 +167,12 @@ class MainManager {
    *
    * @function
    */
-  private async addMapLayer(
-    collectionId: Collection["id"],
-    sourceId: string,
-  ): Promise<void> {
+  private async addMapLayer(collectionId: Collection['id'], sourceId: string): Promise<void> {
     const layerId = this.getLayerId(collectionId);
     if (this.map && !this.map.getLayer(layerId)) {
       this.map.addLayer(getPointLayerDefinition(layerId, sourceId));
 
-      this.map.on("click", layerId, (e) => {
+      this.map.on('click', layerId, (e) => {
         const feature = this.map!.queryRenderedFeatures(e.point, {
           layers: [layerId],
         })?.[0];
@@ -199,14 +191,14 @@ class MainManager {
         }
       });
 
-      this.map.on("mouseenter", layerId, () => {
-        this.map!.getCanvas().style.cursor = "pointer";
+      this.map.on('mouseenter', layerId, () => {
+        this.map!.getCanvas().style.cursor = 'pointer';
       });
-      this.map.on("mousemove", layerId, () => {
-        this.map!.getCanvas().style.cursor = "pointer";
+      this.map.on('mousemove', layerId, () => {
+        this.map!.getCanvas().style.cursor = 'pointer';
       });
-      this.map.on("mouseleave", layerId, () => {
-        this.map!.getCanvas().style.cursor = "";
+      this.map.on('mouseleave', layerId, () => {
+        this.map!.getCanvas().style.cursor = '';
       });
     }
   }
@@ -232,12 +224,126 @@ class MainManager {
   public addCollection(collection: FakeCollection): void {
     const _collection: Collection = {
       id: collection.id,
-      provider: "fake",
-      category: "fake",
-      dataset: "fake",
+      provider: 'fake',
+      category: 'fake',
+      dataset: 'fake',
     };
 
     this.store.getState().addCollection(_collection);
+  }
+
+  /**
+   *
+   * @function
+   */
+  private async getFilterGeometry(
+    collectionId: Collection['id'],
+    itemId: string
+  ): Promise<Feature<Polygon>> {
+    const service = collectionId === SourceId.DoiRegions ? wwdhService : geoconnexService;
+    return service.getItem<Feature<Polygon>>(collectionId, itemId);
+  }
+
+  private addGeographyFilterSource(
+    collectionId: Collection['id'],
+    feature: Feature<Polygon>
+  ): string {
+    const sourceId = this.getSourceId(collectionId);
+    if (this.map) {
+      const source = this.map.getSource(sourceId) as GeoJSONSource;
+      if (!source) {
+        this.map.addSource(sourceId, {
+          type: 'geojson',
+          data: turf.featureCollection([feature]),
+        });
+      } else {
+        source.setData(turf.featureCollection([feature]));
+      }
+    }
+
+    return sourceId;
+  }
+
+  /**
+   *
+   * @function
+   */
+  private addGeographyFilterLayer(collectionId: Collection['id'], sourceId: string): void {
+    const layerId = this.getLayerId(collectionId);
+    if (this.map) {
+      if (!this.map.getLayer(layerId)) {
+        this.map.addLayer(getPolygonLayerDefinition(layerId, sourceId));
+      } else {
+        this.map.setLayoutProperty(layerId, 'visibility', 'visible');
+      }
+    }
+  }
+
+  /**
+   *
+   * @function
+   */
+  private hideIrrelevantGeographyFilterLayers(sourceIds: string[]): void {
+    if (this.map) {
+      sourceIds.forEach((sourceId) => {
+        const layerId = this.getLayerId(sourceId);
+        if (this.map!.getLayer(layerId)) {
+          this.map!.setLayoutProperty(layerId, 'visibility', 'none');
+        }
+      });
+    }
+  }
+
+  /**
+   *
+   * @function
+   */
+  public async updateGeographyFilter(
+    collectionId: Collection['id'],
+    itemId: string
+  ): Promise<void> {
+    const feature = await this.getFilterGeometry(collectionId, itemId);
+
+    const sourceId = this.addGeographyFilterSource(collectionId, feature);
+    this.addGeographyFilterLayer(collectionId, sourceId);
+
+    const otherGeographyFilterSources = GeographyFilterSources.filter(
+      (source) => source !== collectionId
+    );
+
+    this.hideIrrelevantGeographyFilterLayers(otherGeographyFilterSources);
+
+    const bounds = turf.bbox(feature) as LngLatBoundsLike;
+    this.map!.fitBounds(bounds, {
+      padding: 40,
+      speed: 1.2,
+    });
+
+    this.store.getState().setGeographyFilter({
+      itemId,
+      collectionId,
+      feature,
+    });
+  }
+
+  /**
+   *
+   * @function
+   */
+  public removeGeographyFilter(): void {
+    this.hideIrrelevantGeographyFilterLayers(GeographyFilterSources);
+
+    this.map!.fitBounds(
+      [
+        [-125, 24], // Southwest corner (California/Baja)
+        [-96.5, 49], // Northeast corner (MN/ND border)
+      ],
+      {
+        padding: 50,
+      }
+    );
+
+    this.store.getState().setGeographyFilter(null);
   }
 }
 

--- a/hub-ui/src/managers/Main.manager.ts
+++ b/hub-ui/src/managers/Main.manager.ts
@@ -3,18 +3,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as turf from '@turf/turf';
-import { Feature, FeatureCollection, Point, Polygon } from 'geojson';
-import { GeoJSONSource, LngLatBoundsLike, Map } from 'mapbox-gl';
-import { v6 } from 'uuid';
-import { GeoJSONFeature, stringify } from 'wellknown';
-import { StoreApi, UseBoundStore } from 'zustand';
-import { GeographyFilterSources } from '@/features/Map/consts';
-import { SourceId } from '@/features/Map/sources';
-import { getPointLayerDefinition, getPolygonLayerDefinition } from '@/features/Map/utils';
-import geoconnexService from '@/services/init/geoconnex.init';
-import wwdhService from '@/services/init/wwdh.init';
-import { Collection, ColorValueHex, Location, MainState } from '@/stores/main/types';
+import * as turf from "@turf/turf";
+import { Feature, FeatureCollection, Point, Polygon } from "geojson";
+import { GeoJSONSource, LngLatBoundsLike, Map } from "mapbox-gl";
+import { v6 } from "uuid";
+import { GeoJSONFeature, stringify } from "wellknown";
+import { StoreApi, UseBoundStore } from "zustand";
+import { GeographyFilterSources } from "@/features/Map/consts";
+import { SourceId } from "@/features/Map/sources";
+import {
+  getPointLayerDefinition,
+  getPolygonLayerDefinition,
+} from "@/features/Map/utils";
+import geoconnexService from "@/services/init/geoconnex.init";
+import wwdhService from "@/services/init/wwdh.init";
+import {
+  Collection,
+  ColorValueHex,
+  Location,
+  MainState,
+} from "@/stores/main/types";
 
 type FakeCollection = {
   id: string;
@@ -64,7 +72,7 @@ class MainManager {
    * @function
    */
   private createHexColor(): ColorValueHex {
-    return '#fake';
+    return "#fake";
   }
 
   /**
@@ -79,7 +87,7 @@ class MainManager {
    *
    * @function
    */
-  public hasCollection(collectionId: Collection['id']): boolean {
+  public hasCollection(collectionId: Collection["id"]): boolean {
     return this.store.getState().hasCollection(collectionId);
   }
 
@@ -87,7 +95,7 @@ class MainManager {
    *
    * @function
    */
-  public hasLocation(locationId: Location['id']): boolean {
+  public hasLocation(locationId: Location["id"]): boolean {
     return this.store.getState().hasLocation(locationId);
   }
 
@@ -95,7 +103,9 @@ class MainManager {
    *
    * @function
    */
-  public async getData(collectionId: Collection['id']): Promise<FeatureCollection<Point>> {
+  public async getData(
+    collectionId: Collection["id"],
+  ): Promise<FeatureCollection<Point>> {
     const geographyFilter = this.store.getState().geographyFilter;
     if (geographyFilter) {
       const feature = geographyFilter.feature as unknown as GeoJSONFeature;
@@ -108,7 +118,9 @@ class MainManager {
    *
    * @function
    */
-  private async getLocations(collectionId: Collection['id']): Promise<FeatureCollection<Point>> {
+  private async getLocations(
+    collectionId: Collection["id"],
+  ): Promise<FeatureCollection<Point>> {
     return wwdhService.getLocations<FeatureCollection<Point>>(collectionId);
   }
 
@@ -117,13 +129,13 @@ class MainManager {
    * @function
    */
   private async getArea(
-    collectionId: Collection['id'],
-    feature: GeoJSONFeature
+    collectionId: Collection["id"],
+    feature: GeoJSONFeature,
   ): Promise<FeatureCollection<Point>> {
     const wkt = stringify(feature);
 
     return wwdhService.getArea<FeatureCollection<Point>>(collectionId, {
-      method: 'POST',
+      method: "POST",
       params: {
         coords: wkt,
       },
@@ -134,7 +146,7 @@ class MainManager {
    *
    * @function
    */
-  public getSourceId(collectionId: Collection['id']): string {
+  public getSourceId(collectionId: Collection["id"]): string {
     return `${collectionId}-source`;
   }
 
@@ -142,7 +154,7 @@ class MainManager {
    *
    * @function
    */
-  public getLayerId(collectionId: Collection['id']): string {
+  public getLayerId(collectionId: Collection["id"]): string {
     return `${collectionId}-locations`;
   }
 
@@ -150,12 +162,12 @@ class MainManager {
    *
    * @function
    */
-  private async addMapSource(collectionId: Collection['id']): Promise<string> {
+  private async addMapSource(collectionId: Collection["id"]): Promise<string> {
     const sourceId = this.getSourceId(collectionId);
     if (this.map && !this.map.getSource(sourceId)) {
       const data = await this.getData(collectionId);
       this.map.addSource(sourceId, {
-        type: 'geojson',
+        type: "geojson",
         data,
       });
     }
@@ -167,12 +179,15 @@ class MainManager {
    *
    * @function
    */
-  private async addMapLayer(collectionId: Collection['id'], sourceId: string): Promise<void> {
+  private async addMapLayer(
+    collectionId: Collection["id"],
+    sourceId: string,
+  ): Promise<void> {
     const layerId = this.getLayerId(collectionId);
     if (this.map && !this.map.getLayer(layerId)) {
       this.map.addLayer(getPointLayerDefinition(layerId, sourceId));
 
-      this.map.on('click', layerId, (e) => {
+      this.map.on("click", layerId, (e) => {
         const feature = this.map!.queryRenderedFeatures(e.point, {
           layers: [layerId],
         })?.[0];
@@ -191,14 +206,14 @@ class MainManager {
         }
       });
 
-      this.map.on('mouseenter', layerId, () => {
-        this.map!.getCanvas().style.cursor = 'pointer';
+      this.map.on("mouseenter", layerId, () => {
+        this.map!.getCanvas().style.cursor = "pointer";
       });
-      this.map.on('mousemove', layerId, () => {
-        this.map!.getCanvas().style.cursor = 'pointer';
+      this.map.on("mousemove", layerId, () => {
+        this.map!.getCanvas().style.cursor = "pointer";
       });
-      this.map.on('mouseleave', layerId, () => {
-        this.map!.getCanvas().style.cursor = '';
+      this.map.on("mouseleave", layerId, () => {
+        this.map!.getCanvas().style.cursor = "";
       });
     }
   }
@@ -224,9 +239,9 @@ class MainManager {
   public addCollection(collection: FakeCollection): void {
     const _collection: Collection = {
       id: collection.id,
-      provider: 'fake',
-      category: 'fake',
-      dataset: 'fake',
+      provider: "fake",
+      category: "fake",
+      dataset: "fake",
     };
 
     this.store.getState().addCollection(_collection);
@@ -237,23 +252,24 @@ class MainManager {
    * @function
    */
   private async getFilterGeometry(
-    collectionId: Collection['id'],
-    itemId: string
+    collectionId: Collection["id"],
+    itemId: string,
   ): Promise<Feature<Polygon>> {
-    const service = collectionId === SourceId.DoiRegions ? wwdhService : geoconnexService;
+    const service =
+      collectionId === SourceId.DoiRegions ? wwdhService : geoconnexService;
     return service.getItem<Feature<Polygon>>(collectionId, itemId);
   }
 
   private addGeographyFilterSource(
-    collectionId: Collection['id'],
-    feature: Feature<Polygon>
+    collectionId: Collection["id"],
+    feature: Feature<Polygon>,
   ): string {
     const sourceId = this.getSourceId(collectionId);
     if (this.map) {
       const source = this.map.getSource(sourceId) as GeoJSONSource;
       if (!source) {
         this.map.addSource(sourceId, {
-          type: 'geojson',
+          type: "geojson",
           data: turf.featureCollection([feature]),
         });
       } else {
@@ -268,13 +284,16 @@ class MainManager {
    *
    * @function
    */
-  private addGeographyFilterLayer(collectionId: Collection['id'], sourceId: string): void {
+  private addGeographyFilterLayer(
+    collectionId: Collection["id"],
+    sourceId: string,
+  ): void {
     const layerId = this.getLayerId(collectionId);
     if (this.map) {
       if (!this.map.getLayer(layerId)) {
         this.map.addLayer(getPolygonLayerDefinition(layerId, sourceId));
       } else {
-        this.map.setLayoutProperty(layerId, 'visibility', 'visible');
+        this.map.setLayoutProperty(layerId, "visibility", "visible");
       }
     }
   }
@@ -288,7 +307,7 @@ class MainManager {
       sourceIds.forEach((sourceId) => {
         const layerId = this.getLayerId(sourceId);
         if (this.map!.getLayer(layerId)) {
-          this.map!.setLayoutProperty(layerId, 'visibility', 'none');
+          this.map!.setLayoutProperty(layerId, "visibility", "none");
         }
       });
     }
@@ -299,8 +318,8 @@ class MainManager {
    * @function
    */
   public async updateGeographyFilter(
-    collectionId: Collection['id'],
-    itemId: string
+    collectionId: Collection["id"],
+    itemId: string,
   ): Promise<void> {
     const feature = await this.getFilterGeometry(collectionId, itemId);
 
@@ -308,7 +327,7 @@ class MainManager {
     this.addGeographyFilterLayer(collectionId, sourceId);
 
     const otherGeographyFilterSources = GeographyFilterSources.filter(
-      (source) => source !== collectionId
+      (source) => source !== collectionId,
     );
 
     this.hideIrrelevantGeographyFilterLayers(otherGeographyFilterSources);
@@ -340,7 +359,7 @@ class MainManager {
       ],
       {
         padding: 50,
-      }
+      },
     );
 
     this.store.getState().setGeographyFilter(null);

--- a/hub-ui/src/pages/Layout.page.tsx
+++ b/hub-ui/src/pages/Layout.page.tsx
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Box, Group, Stack } from "@mantine/core";
-import DownloadModal from "@/features/Download/Modal";
-import Loading from "@/features/Loading";
-import Map from "@/features/Map";
-import Notifications from "@/features/Notifications";
-import Panel from "@/features/Panel";
-import styles from "@/pages/pages.module.css";
-import Download from "../features/Download";
+import { Box, Group, Stack } from '@mantine/core';
+import DownloadModal from '@/features/Download/Modal';
+import Loading from '@/features/Loading';
+import Map from '@/features/Map';
+import Notifications from '@/features/Notifications';
+import Panel from '@/features/Panel';
+import styles from '@/pages/pages.module.css';
+import Download from '../features/Download';
 
 export const LayoutPage: React.FC = () => {
   return (

--- a/hub-ui/src/pages/Layout.page.tsx
+++ b/hub-ui/src/pages/Layout.page.tsx
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Box, Group, Stack } from '@mantine/core';
-import DownloadModal from '@/features/Download/Modal';
-import Loading from '@/features/Loading';
-import Map from '@/features/Map';
-import Notifications from '@/features/Notifications';
-import Panel from '@/features/Panel';
-import styles from '@/pages/pages.module.css';
-import Download from '../features/Download';
+import { Box, Group, Stack } from "@mantine/core";
+import DownloadModal from "@/features/Download/Modal";
+import Loading from "@/features/Loading";
+import Map from "@/features/Map";
+import Notifications from "@/features/Notifications";
+import Panel from "@/features/Panel";
+import styles from "@/pages/pages.module.css";
+import Download from "../features/Download";
 
 export const LayoutPage: React.FC = () => {
   return (

--- a/hub-ui/src/stores/main/types.ts
+++ b/hub-ui/src/stores/main/types.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Feature, FeatureCollection, Polygon } from "geojson";
-import { Properties } from "@/components/Map/types";
+import { Feature, FeatureCollection, Polygon } from 'geojson';
+import { Properties } from '@/components/Map/types';
 
 export type ColorValueHex = `#${string}`;
 
 enum SpatialSelectionType {
-  Drawn = "custom-drawn-polygon",
-  Selected = "select-existing-polygons",
-  Upload = "custom-upload-shape",
+  Drawn = 'custom-drawn-polygon',
+  Selected = 'select-existing-polygons',
+  Upload = 'custom-upload-shape',
 }
 
 interface SpatialSelectionBase {
@@ -40,10 +40,10 @@ export type SpatialSelection =
   | SpatialSelectionSelected;
 
 export enum DatasourceType {
-  Point = "point",
-  Line = "line",
-  Polygon = "polygon",
-  Raster = "raster",
+  Point = 'point',
+  Line = 'line',
+  Polygon = 'polygon',
+  Raster = 'raster',
 }
 
 export type Collection = {
@@ -56,31 +56,37 @@ export type Collection = {
 
 export type Layer = {
   id: string; // uuid
-  collectionId: Collection["id"];
+  collectionId: Collection['id'];
 };
 
 export type Location = {
   id: string | number; // location/{this}
-  collectionId: Collection["id"];
+  collectionId: Collection['id'];
+};
+
+export type GeographyFilter = {
+  itemId: string;
+  collectionId: Collection['id'];
+  feature: Feature<Polygon>;
 };
 
 export interface MainState {
   provider: string | null;
-  setProvider: (provider: MainState["provider"]) => void;
+  setProvider: (provider: MainState['provider']) => void;
   category: string | null;
-  setCategory: (category: MainState["category"]) => void;
+  setCategory: (category: MainState['category']) => void;
   dataset: string | null;
-  setDataset: (dataset: MainState["dataset"]) => void;
-  geographyFilter: Feature<Polygon> | null;
-  setGeographyFilter: (geographyFilter: MainState["geographyFilter"]) => void;
+  setDataset: (dataset: MainState['dataset']) => void;
+  geographyFilter: GeographyFilter | null;
+  setGeographyFilter: (geographyFilter: MainState['geographyFilter']) => void;
   hasGeographyFilter: () => boolean;
   collections: Collection[];
-  setCollections: (collections: MainState["collections"]) => void;
+  setCollections: (collections: MainState['collections']) => void;
   addCollection: (collection: Collection) => void;
-  hasCollection: (collectionId: Collection["id"]) => boolean;
+  hasCollection: (collectionId: Collection['id']) => boolean;
   locations: Location[];
-  setLocations: (locations: MainState["locations"]) => void;
+  setLocations: (locations: MainState['locations']) => void;
   addLocation: (location: Location) => void;
-  hasLocation: (locationId: Location["id"]) => boolean;
-  removeLocation: (locationId: Location["id"]) => void;
+  hasLocation: (locationId: Location['id']) => boolean;
+  removeLocation: (locationId: Location['id']) => void;
 }

--- a/hub-ui/src/stores/main/types.ts
+++ b/hub-ui/src/stores/main/types.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Feature, FeatureCollection, Polygon } from 'geojson';
-import { Properties } from '@/components/Map/types';
+import { Feature, FeatureCollection, Polygon } from "geojson";
+import { Properties } from "@/components/Map/types";
 
 export type ColorValueHex = `#${string}`;
 
 enum SpatialSelectionType {
-  Drawn = 'custom-drawn-polygon',
-  Selected = 'select-existing-polygons',
-  Upload = 'custom-upload-shape',
+  Drawn = "custom-drawn-polygon",
+  Selected = "select-existing-polygons",
+  Upload = "custom-upload-shape",
 }
 
 interface SpatialSelectionBase {
@@ -40,10 +40,10 @@ export type SpatialSelection =
   | SpatialSelectionSelected;
 
 export enum DatasourceType {
-  Point = 'point',
-  Line = 'line',
-  Polygon = 'polygon',
-  Raster = 'raster',
+  Point = "point",
+  Line = "line",
+  Polygon = "polygon",
+  Raster = "raster",
 }
 
 export type Collection = {
@@ -56,37 +56,37 @@ export type Collection = {
 
 export type Layer = {
   id: string; // uuid
-  collectionId: Collection['id'];
+  collectionId: Collection["id"];
 };
 
 export type Location = {
   id: string | number; // location/{this}
-  collectionId: Collection['id'];
+  collectionId: Collection["id"];
 };
 
 export type GeographyFilter = {
   itemId: string;
-  collectionId: Collection['id'];
+  collectionId: Collection["id"];
   feature: Feature<Polygon>;
 };
 
 export interface MainState {
   provider: string | null;
-  setProvider: (provider: MainState['provider']) => void;
+  setProvider: (provider: MainState["provider"]) => void;
   category: string | null;
-  setCategory: (category: MainState['category']) => void;
+  setCategory: (category: MainState["category"]) => void;
   dataset: string | null;
-  setDataset: (dataset: MainState['dataset']) => void;
+  setDataset: (dataset: MainState["dataset"]) => void;
   geographyFilter: GeographyFilter | null;
-  setGeographyFilter: (geographyFilter: MainState['geographyFilter']) => void;
+  setGeographyFilter: (geographyFilter: MainState["geographyFilter"]) => void;
   hasGeographyFilter: () => boolean;
   collections: Collection[];
-  setCollections: (collections: MainState['collections']) => void;
+  setCollections: (collections: MainState["collections"]) => void;
   addCollection: (collection: Collection) => void;
-  hasCollection: (collectionId: Collection['id']) => boolean;
+  hasCollection: (collectionId: Collection["id"]) => boolean;
   locations: Location[];
-  setLocations: (locations: MainState['locations']) => void;
+  setLocations: (locations: MainState["locations"]) => void;
   addLocation: (location: Location) => void;
-  hasLocation: (locationId: Location['id']) => boolean;
-  removeLocation: (locationId: Location['id']) => void;
+  hasLocation: (locationId: Location["id"]) => boolean;
+  removeLocation: (locationId: Location["id"]) => void;
 }

--- a/hub-ui/src/types/region.ts
+++ b/hub-ui/src/types/region.ts
@@ -4,13 +4,21 @@
  */
 
 export enum RegionField {
-  ObjectId = "OBJECTID",
-  RegNum = "REG_NUM",
-  Name = "REG_NAME",
-  AreaSqMi = "AREA_SQMI",
-  AreaAcres = "AREA_ACRES",
-  ShapeArea = "Shape__Area",
-  ShapeLength = "Shape__Length",
+  ObjectId = 'OBJECTID',
+  RegNum = 'REG_NUM',
+  Name = 'REG_NAME',
+  AreaSqMi = 'AREA_SQMI',
+  AreaAcres = 'AREA_ACRES',
+  ShapeArea = 'Shape__Area',
+  ShapeLength = 'Shape__Length',
+  GlobalID = 'GlobalID',
+  CreationDate = 'CreationDate',
+  Creator = 'Creator',
+  EditDate = 'EditDate',
+  Editor = 'Editor',
+  InteriorRegion = 'InteriorRegion',
+  OfficialAbbreviation = 'OfficialAbbreviation',
+  UsbrXs = 'usbr_xs',
 }
 
 export type RegionProperties = {
@@ -21,4 +29,12 @@ export type RegionProperties = {
   [RegionField.AreaAcres]: number;
   [RegionField.ShapeArea]: number;
   [RegionField.ShapeLength]: number;
+  [RegionField.GlobalID]: string;
+  [RegionField.CreationDate]: number;
+  [RegionField.Creator]: string;
+  [RegionField.EditDate]: number;
+  [RegionField.Editor]: string;
+  [RegionField.InteriorRegion]: string | null;
+  [RegionField.OfficialAbbreviation]: string | null;
+  [RegionField.UsbrXs]: unknown | null;
 };

--- a/hub-ui/src/types/region.ts
+++ b/hub-ui/src/types/region.ts
@@ -4,21 +4,21 @@
  */
 
 export enum RegionField {
-  ObjectId = 'OBJECTID',
-  RegNum = 'REG_NUM',
-  Name = 'REG_NAME',
-  AreaSqMi = 'AREA_SQMI',
-  AreaAcres = 'AREA_ACRES',
-  ShapeArea = 'Shape__Area',
-  ShapeLength = 'Shape__Length',
-  GlobalID = 'GlobalID',
-  CreationDate = 'CreationDate',
-  Creator = 'Creator',
-  EditDate = 'EditDate',
-  Editor = 'Editor',
-  InteriorRegion = 'InteriorRegion',
-  OfficialAbbreviation = 'OfficialAbbreviation',
-  UsbrXs = 'usbr_xs',
+  ObjectId = "OBJECTID",
+  RegNum = "REG_NUM",
+  Name = "REG_NAME",
+  AreaSqMi = "AREA_SQMI",
+  AreaAcres = "AREA_ACRES",
+  ShapeArea = "Shape__Area",
+  ShapeLength = "Shape__Length",
+  GlobalID = "GlobalID",
+  CreationDate = "CreationDate",
+  Creator = "Creator",
+  EditDate = "EditDate",
+  Editor = "Editor",
+  InteriorRegion = "InteriorRegion",
+  OfficialAbbreviation = "OfficialAbbreviation",
+  UsbrXs = "usbr_xs",
 }
 
 export type RegionProperties = {


### PR DESCRIPTION
### **Description:**
Connected geography filters to map and global state. Should now update on map and in the backing logic.

### **Acceptance Criteria:**
- Selected filter should render on map and map should zoom to feature
- Selecting a different filter ie (Region -> Basin) should clear the previous filter and remove the previous feature
- Clearing a filter should reset the map view

**NOTE**
- The "Update Data" button will not work with a selected geography filter, it currently posts the geography filter feature as a wkt string in a post request to "/area"