### PR TITLE
Make updateDate optional to fix serialization issue

### DIFF
--- a/packages/rise/rise/lib/location.py
+++ b/packages/rise/rise/lib/location.py
@@ -139,19 +139,20 @@ class LocationCollection(LocationCollectionProtocol):
             start, end = parsed_date
 
             for i, location in enumerate(self.locations):
+                if not location.attributes.updateDate:
+                    location_indices_to_remove.add(i)
+                    continue
                 updateDate = datetime.fromisoformat(location.attributes.updateDate)
                 if updateDate < start or updateDate > end:
                     location_indices_to_remove.add(i)
 
         elif isinstance(parsed_date, datetime) == 1:
             parsed_date_str = str(parsed_date)
-            self.locations = [
-                location
-                for location in self.locations
-                if location.attributes.updateDate.startswith(parsed_date_str)
-            ]
+
             for i, location in enumerate(self.locations):
-                if not location.attributes.updateDate.startswith(parsed_date_str):
+                if not location.attributes.updateDate:
+                    location_indices_to_remove.add(i)
+                elif not location.attributes.updateDate.startswith(parsed_date_str):
                     location_indices_to_remove.add(i)
 
         else:

--- a/packages/rise/rise/lib/types/location.py
+++ b/packages/rise/rise/lib/types/location.py
@@ -57,7 +57,7 @@ class LocationDataAttributes(BaseModel):
     ] = Field(discriminator="type")
     elevation: Optional[float] = None
     createDate: str
-    updateDate: str
+    updateDate: Optional[str]
     horizontalDatum: dict
     locationGeometry: dict
     timezone: Optional[str] = None

--- a/pygeoapi-deployment/pygeoapi.config.yml
+++ b/pygeoapi-deployment/pygeoapi.config.yml
@@ -54,7 +54,7 @@ resources:
   rise-edr:
     type: collection
     title: Reclamation Information Sharing Environment
-    description: USBR Information Sharing Environment EDR
+    description: USBR Information Sharing Environment (RISE) EDR
     provider-name:
       - BOR
       - USBR


### PR DESCRIPTION
Rise changed their schema and updateDate is now optional. As such I needed to make a property optional such that it does not fail