### PR TITLE
Fix label in snotel; it should be snow water equivalent not temp

### DIFF
--- a/dashboard-ui/src/app/hooks/useSnotelData.ts
+++ b/dashboard-ui/src/app/hooks/useSnotelData.ts
@@ -53,9 +53,9 @@ export const useSnotelData = () => {
                     .forEach((loc) => {
                         loc.properties = {
                             ...loc.properties,
-                            [SnotelHucMeansField.SnowpackTempRelative]:
+                            [SnotelHucMeansField.CurrentRelativeSnowWaterEquivalent]:
                                 mean.properties[
-                                    SnotelHucMeansField.SnowpackTempRelative
+                                    SnotelHucMeansField.CurrentRelativeSnowWaterEquivalent
                                 ],
                         };
                     });

--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -452,7 +452,7 @@ export const getLayerConfig = (
                 id: LayerId.Snotel,
                 type: LayerType.Circle,
                 source: SourceId.Snotel,
-                filter: ['has', SnotelHucMeansField.SnowpackTempRelative],
+                filter: ['has', SnotelHucMeansField.CurrentRelativeSnowWaterEquivalent],
                 paint: {
                     'circle-radius': 5,
                     'circle-stroke-width': 1,
@@ -461,7 +461,7 @@ export const getLayerConfig = (
                         'step',
                         [
                             'coalesce',
-                            ['get', SnotelHucMeansField.SnowpackTempRelative],
+                            ['get', SnotelHucMeansField.CurrentRelativeSnowWaterEquivalent],
                             -1,
                         ],
                         '#fff',

--- a/dashboard-ui/src/features/Map/types/snotel.ts
+++ b/dashboard-ui/src/features/Map/types/snotel.ts
@@ -41,7 +41,7 @@ export type SnotelProperties = {
     [SnotelField.StationElements]: null;
     [SnotelField.StationId]: string;
     [SnotelField.StationTriplet]: string;
-    [SnotelHucMeansField.SnowpackTempRelative]?: number; // appended field
+    [SnotelHucMeansField.CurrentRelativeSnowWaterEquivalent]?: number; // appended field
 };
 
 export enum SnotelHucMeansField {
@@ -50,7 +50,7 @@ export enum SnotelHucMeansField {
     GnisUrl = 'gnis_url',
     LoadDate = 'loaddate',
     Name = 'name',
-    SnowpackTempRelative = 'snowpack_water_temp_avg_relative_to_thirty_year_avg',
+    CurrentRelativeSnowWaterEquivalent = 'current_snow_water_equivalent_relative_to_thirty_year_avg',
     Uri = 'uri',
 }
 
@@ -60,6 +60,6 @@ export type SnotelHucMeansProperties = {
     [SnotelHucMeansField.GnisUrl]: string;
     [SnotelHucMeansField.LoadDate]: string; // ISO date string
     [SnotelHucMeansField.Name]: string;
-    [SnotelHucMeansField.SnowpackTempRelative]: number;
+    [SnotelHucMeansField.CurrentRelativeSnowWaterEquivalent]: number;
     [SnotelHucMeansField.Uri]: string;
 };

--- a/packages/snotel_means/snotel_means/lib/location_test.py
+++ b/packages/snotel_means/snotel_means/lib/location_test.py
@@ -3,23 +3,23 @@
 
 
 from snotel_means.lib.locations import (
-    WaterTemperatureCollectionWithMetadata,
-    get_30_year_water_temp_average,
+    SnowWaterEquivalentCollectionWithMetadata,
+    get_30_year_snow_water_equivalent_average,
     get_all_snotel_station_metadata,
-    get_water_temp,
+    get_daily_snow_water_equivalent,
     get_yesterdays_month_and_day,
 )
 
 
 def test_get_30_year_water_temp_avg():
     yesterday = get_yesterdays_month_and_day()
-    mapper = get_30_year_water_temp_average(yesterday)
+    mapper = get_30_year_snow_water_equivalent_average(yesterday)
     assert len(mapper) > 0
 
 
 def test_get_water_temp():
     yesterday = get_yesterdays_month_and_day()
-    mapper = get_30_year_water_temp_average(yesterday)
+    mapper = get_30_year_snow_water_equivalent_average(yesterday)
     assert len(mapper) > 0
 
 
@@ -30,13 +30,13 @@ def test_get_geometry():
 
 def test_construct_collection():
     yesterday = get_yesterdays_month_and_day()
-    averages = get_30_year_water_temp_average(yesterday)
+    averages = get_30_year_snow_water_equivalent_average(yesterday)
     assert len(averages) > 0
 
-    daily = get_water_temp(yesterday)
+    daily = get_daily_snow_water_equivalent(yesterday)
     assert len(daily) > 0
 
-    collection = WaterTemperatureCollectionWithMetadata._make_station_dict(
+    collection = SnowWaterEquivalentCollectionWithMetadata._make_station_dict(
         averages, daily
     )
     assert len(collection) > 0

--- a/packages/snotel_means/snotel_means/snotel_means.py
+++ b/packages/snotel_means/snotel_means/snotel_means.py
@@ -21,7 +21,7 @@ from com.cache import RedisCache
 from awdb_com.types import StationDTO
 
 from snotel_means.lib.locations import (
-    WaterTemperatureCollectionWithMetadata,
+    SnowWaterEquivalentCollectionWithMetadata,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -67,7 +67,7 @@ class SnotelMeansProvider(BaseProvider, OAFProviderProtocol):
         skip_geometry: Optional[bool] = False,
         **kwargs,
     ) -> GeojsonFeatureCollectionDict | GeojsonFeatureDict:
-        collection = WaterTemperatureCollectionWithMetadata()
+        collection = SnowWaterEquivalentCollectionWithMetadata()
 
         hucToAverage = collection.get_averages_by_huc6()
         relevant_features: list[geojson_pydantic.Feature] = []
@@ -85,7 +85,7 @@ class SnotelMeansProvider(BaseProvider, OAFProviderProtocol):
             mergedDict: dict = featureProperties.copy()
             mergedDict.update(
                 {
-                    "snowpack_water_temp_avg_relative_to_thirty_year_avg": hucToAverage[
+                    "current_snow_water_equivalent_relative_to_thirty_year_avg": hucToAverage[
                         huc6
                     ]
                 }


### PR DESCRIPTION
I had mistakenly labelled WTEQ and WTEQV as water temperature. In reality they are snow water equivalent. This makes more sense. I have added context here #158 