### PR TITLE
Change USACE to callout access 2 water

### DIFF
--- a/dashboard-ui/src/features/Map/consts.ts
+++ b/dashboard-ui/src/features/Map/consts.ts
@@ -22,7 +22,7 @@ export enum SourceId {
     States = 'states',
     RiseEDRReservoirs = 'rise-edr',
     ResvizEDRReservoirs = 'resviz-edr',
-    USACEEDRReservoirs = 'usace-access2water-edr',
+    USACEEDRReservoirs = 'usace-edr',
     SnowWater = 'snow-water',
     USDroughtMonitor = 'us-drought-monitor',
     NOAAPrecipSixToTen = 'noaa-precip-6-10-day',

--- a/dashboard-ui/src/features/Map/consts.ts
+++ b/dashboard-ui/src/features/Map/consts.ts
@@ -22,7 +22,7 @@ export enum SourceId {
     States = 'states',
     RiseEDRReservoirs = 'rise-edr',
     ResvizEDRReservoirs = 'resviz-edr',
-    USACEEDRReservoirs = 'usace-edr',
+    USACEEDRReservoirs = 'usace-access2water-edr',
     SnowWater = 'snow-water',
     USDroughtMonitor = 'us-drought-monitor',
     NOAAPrecipSixToTen = 'noaa-precip-6-10-day',

--- a/pygeoapi-deployment/pygeoapi.config.yml
+++ b/pygeoapi-deployment/pygeoapi.config.yml
@@ -183,7 +183,7 @@ resources:
         entity: Observation
         title_field: name
 
-  usace-access2water-edr:
+  usace-edr:
     type: collection
     title: US Army Corps of Engineers Access2Water
     description: USACE Access2Water (A2W) API EDR

--- a/pygeoapi-deployment/pygeoapi.config.yml
+++ b/pygeoapi-deployment/pygeoapi.config.yml
@@ -183,10 +183,10 @@ resources:
         entity: Observation
         title_field: name
 
-  usace-edr:
+  usace-access2water-edr:
     type: collection
-    title: US Army Corps of Engineers
-    description: USACE Access2Water API
+    title: US Army Corps of Engineers Access2Water
+    description: USACE Access2Water (A2W) API EDR
     provider-name:
       - DOA
       - USACE


### PR DESCRIPTION
I believe the usace should be labelled specifically as USACE Access 2 Water since that is the name of the dataset and there are multiple USACE APIs that are worth distinguishing from.