### PR TITLE
Rename USACE Acces2Water collection

### DIFF
--- a/pygeoapi-deployment/pygeoapi.config.yml
+++ b/pygeoapi-deployment/pygeoapi.config.yml
@@ -183,7 +183,7 @@ resources:
 
   usace-edr:
     type: collection
-    title: US Army Corps of Engineers
+    title: Access2Water
     description: USACE Access2Water API
     provider-name:
       - DOA

--- a/pygeoapi-deployment/pygeoapi.config.yml
+++ b/pygeoapi-deployment/pygeoapi.config.yml
@@ -183,7 +183,7 @@ resources:
 
   usace-edr:
     type: collection
-    title: Access2Water
+    title: US Army Corps of Engineers
     description: USACE Access2Water API
     provider-name:
       - DOA

--- a/uv.lock
+++ b/uv.lock
@@ -1541,7 +1541,7 @@ wheels = [
 [[package]]
 name = "pygeoapi"
 version = "0.22.dev0"
-source = { git = "https://github.com/internetofwater/pygeoapi.git?rev=wwdh#72b17d847561bc3abbd9068a4e5ea94c172c9c93" }
+source = { git = "https://github.com/internetofwater/pygeoapi.git?rev=wwdh#d44fef51b5e792e0e49ceebeddad01406b96cac4" }
 dependencies = [
     { name = "babel" },
     { name = "click" },


### PR DESCRIPTION
- Rename USACE Access2Water collection
- Bump pygeoapi w/ following changes
  - Use Collection Name instead of collection id in parameter group dropdowns
  - Allow `parameter-name` filter to match on common term or uri