### PR TITLE
fix usace template to handle special characters

### DIFF
--- a/pygeoapi-deployment/templates/jsonld/usace-edr/collections/items/item.jsonld
+++ b/pygeoapi-deployment/templates/jsonld/usace-edr/collections/items/item.jsonld
@@ -8,10 +8,13 @@
     "schema:name": "{{data["public_name"]}}",
     "schema:identifier": "{{data["id"]}}",
     "schema:dateModified": "{{data["dataUpdated"]}}",
-    "schema:description": "{{data["projectDescription"]}}",
+    {% if data["projectDescription"] %}
+    "schema:description": "{{ data["projectDescription"].replace('\n', ' ').replace('\r', '').replace('"', '\'').replace("\t", " ") }}",
+    {% endif %}
     "gsp:hasGeometry": {{ data["gsp:hasGeometry"] | to_json }}, 
-    "schema:geo": {{ data["schema:geo"] | to_json }},
-    "schema:subjectOf": [
+    "schema:geo": {{ data["schema:geo"] | to_json }}
+    {% if data["timeseries"] %}
+    ,"schema:subjectOf": [
     {% for element in data["timeseries"] %}{
         "@type": "schema:Dataset",
         "schema:identifier": "{{element["label"]}}",
@@ -33,4 +36,5 @@
     }{% if not loop.last %},{% endif %}
     {% endfor %}
     ]
+    {% endif %}
 }


### PR DESCRIPTION
USACE has some properties with special characters like \n that for some reason cause json parsing errors and thus new to just be replaced entirely

Validated this with the following command

```
docker run internetofwater/shacl_validator_grpc_py:latest generate_geoconnex_csv --oaf_items_endpoint http://host.docker.internal:5005/collections/usace-edr/items --description "US Army Corps of Engineers Access To Water API" --contact_email cloftus@lincolninst.edu --validate_shacl --geoconnex_namespace wwdh/usace
```