### PR TITLE
Fix hot reload of server in dev mode

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 # Variables
-PYGEOAPI_CONFIG = pygeoapi-deployment/pygeoapi.config.yml
+PYGEOAPI_CONFIG = pygeoapi.config.yml
 PYGEOAPI_OPENAPI = local.openapi.yml
 
 # install dependencies
@@ -11,12 +11,12 @@ deps:
 dev: 
 	OTEL_SDK_DISABLED=false uv run pygeoapi openapi generate $(PYGEOAPI_CONFIG) --output-file $(PYGEOAPI_OPENAPI)
 # 	we must be in the pygeoapi-deployment directory for the templates to have the right relative path
-	cd pygeoapi-deployment && OTEL_SDK_DISABLED=false PYGEOAPI_CONFIG=../$(PYGEOAPI_CONFIG) PYGEOAPI_OPENAPI=../$(PYGEOAPI_OPENAPI) uv run pygeoapi serve --starlette
+	OTEL_SDK_DISABLED=false PYGEOAPI_CONFIG=$(PYGEOAPI_CONFIG) PYGEOAPI_OPENAPI=$(PYGEOAPI_OPENAPI) uv run pygeoapi serve --starlette
 
 devNoOTEL:
 	OTEL_SDK_DISABLED=true uv run pygeoapi openapi generate $(PYGEOAPI_CONFIG) --output-file $(PYGEOAPI_OPENAPI)
 # 	we must be in the pygeoapi-deployment directory for the templates to have the right relative path
-	cd pygeoapi-deployment && OTEL_SDK_DISABLED=true PYGEOAPI_CONFIG=../$(PYGEOAPI_CONFIG) PYGEOAPI_OPENAPI=../$(PYGEOAPI_OPENAPI) uv run pygeoapi serve --starlette
+	OTEL_SDK_DISABLED=true PYGEOAPI_CONFIG=$(PYGEOAPI_CONFIG) PYGEOAPI_OPENAPI=$(PYGEOAPI_OPENAPI) uv run pygeoapi serve --starlette
 
 test:
 	# run tests in parallel with pytest-xdist and stop after first failure; run in verbose mode and show durations of the 5 slowest tests

--- a/pygeoapi-deployment/Dockerfile
+++ b/pygeoapi-deployment/Dockerfile
@@ -35,6 +35,7 @@ COPY packages /opt/pygeoapi/packages/
 RUN uv sync --all-packages --inexact 
 
 COPY pygeoapi-deployment/ /opt/pygeoapi/pygeoapi-deployment/
+COPY pygeoapi.config.yml /opt/pygeoapi/pygeoapi.config.yml
 
 RUN cp /opt/pygeoapi/packages/resviz/resviz.crontab /etc/cron.d/resviz-cron && \
     chmod 0644 /etc/cron.d/resviz-cron && \
@@ -43,6 +44,7 @@ RUN cp /opt/pygeoapi/packages/resviz/resviz.crontab /etc/cron.d/resviz-cron && \
 
 # Set up environment
 ENV PATH="/opt/pygeoapi/.venv/bin:$PATH"
+ENV CONFIG_FILE="/opt/pygeoapi/pygeoapi.config.yml"
 
 # Entrypoint for running the app
 ENTRYPOINT [ "/opt/pygeoapi/pygeoapi-deployment/entrypoint.sh" ]

--- a/pygeoapi-deployment/Dockerfile
+++ b/pygeoapi-deployment/Dockerfile
@@ -44,7 +44,6 @@ RUN cp /opt/pygeoapi/packages/resviz/resviz.crontab /etc/cron.d/resviz-cron && \
 
 # Set up environment
 ENV PATH="/opt/pygeoapi/.venv/bin:$PATH"
-ENV CONFIG_FILE="/opt/pygeoapi/pygeoapi.config.yml"
 
 # Entrypoint for running the app
 ENTRYPOINT [ "/opt/pygeoapi/pygeoapi-deployment/entrypoint.sh" ]

--- a/pygeoapi-deployment/entrypoint.sh
+++ b/pygeoapi-deployment/entrypoint.sh
@@ -10,8 +10,8 @@ echo "START /entrypoint.sh"
 set +e
 
 export PYGEOAPI_HOME=/opt/pygeoapi
-export PYGEOAPI_CONFIG="/opt/pygeoapi/pygeoapi.config.yml"
-export PYGEOAPI_OPENAPI="/opt/pygeoapi/pygeoapi.openapi.yml"
+export PYGEOAPI_CONFIG="${PYGEOAPI_HOME}/pygeoapi.config.yml"
+export PYGEOAPI_OPENAPI="${PYGEOAPI_HOME}/pygeoapi.openapi.yml"
 
 # gunicorn env settings with defaults
 SCRIPT_NAME=${SCRIPT_NAME:=/}

--- a/pygeoapi-deployment/entrypoint.sh
+++ b/pygeoapi-deployment/entrypoint.sh
@@ -9,9 +9,9 @@ echo "START /entrypoint.sh"
 
 set +e
 
-export PYGEOAPI_HOME=/opt/pygeoapi/pygeoapi-deployment
-export PYGEOAPI_CONFIG="${PYGEOAPI_HOME}/pygeoapi.config.yml"
-export PYGEOAPI_OPENAPI="${PYGEOAPI_HOME}/pygeoapi.openapi.yml"
+export PYGEOAPI_HOME=/opt/pygeoapi
+export PYGEOAPI_CONFIG="/opt/pygeoapi/pygeoapi.config.yml"
+export PYGEOAPI_OPENAPI="/opt/pygeoapi/pygeoapi.openapi.yml"
 
 # gunicorn env settings with defaults
 SCRIPT_NAME=${SCRIPT_NAME:=/}

--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -61,7 +61,7 @@ resources:
       - RISE
       - USBR
     templates:
-      path: templates/jsonld/rise-edr
+      path: pygeoapi-deployment/templates/jsonld/rise-edr
     links:
       - &default-link
         type: application/html
@@ -99,7 +99,7 @@ resources:
       - NRCS
       - USDA
     templates:
-      path: templates/jsonld/snotel
+      path: pygeoapi-deployment/templates/jsonld/snotel
     links:
       - <<: *default-link
         href: https://www.nrcs.usda.gov/wps/portal/wcc/home/aboutUs/monitoringPrograms/automatedSnowMonitoring/
@@ -167,7 +167,7 @@ resources:
       - <<: *default-link
         href: https://www.nrcs.usda.gov/wps/portal/wcc/home/aboutUs/monitoringPrograms/automatedSnowMonitoring
     templates:
-      path: templates/jsonld/snotel
+      path: pygeoapi-deployment/templates/jsonld/snotel
 
   snotel-huc06-means:
     type: collection
@@ -198,7 +198,7 @@ resources:
     keywords:
       - open data
     templates:
-      path: templates/jsonld/usace-edr
+      path: pygeoapi-deployment/templates/jsonld/usace-edr
     extents: *default-extent
     providers:
       - type: edr
@@ -411,7 +411,7 @@ resources:
         href: https://www.cbrfc.noaa.gov/wsup/graph/west/map/esp_map.html
     extents: *default-extent
     templates:
-      path: templates/jsonld/noaa_rfc
+      path: pygeoapi-deployment/templates/jsonld/noaa_rfc
     providers:
       - type: feature
         name: noaa_rfc.noaa_rfc.NOAARFCProvider


### PR DESCRIPTION
Previously when I implemented templating, I moved the config into the deployment directory to make the relative paths right.

However, in order for pygeoapi to hot reload properly the config must be at the root. Thus, I moved the config to root and updated some of the paths

This works both in `dev` mode and does not affect the container build with docker build