### PR TITLE
Fix noaa UI and make backend have a static `latest_esppavg` property

### DIFF
--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -767,7 +767,7 @@ export const getLayerMouseMoveFunction = (
                                 'espname'
                             ] as string;
                             const average = Number(
-                                feature.properties['espplatest_esppavgavg']
+                                feature.properties['esppavg']
                             ).toFixed(1);
                             const html = `
                                 <div>

--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -767,7 +767,7 @@ export const getLayerMouseMoveFunction = (
                                 'espname'
                             ] as string;
                             const average = Number(
-                                feature.properties['esppavg']
+                                feature.properties['latest_esppavg']
                             ).toFixed(1);
                             const html = `
                                 <div>
@@ -883,9 +883,14 @@ export const getLayerClickFunction = (
                             const imageLink = feature.properties[
                                 'image_plot_link'
                             ] as string;
+                            const datasetLink = feature.properties[
+                                'dataset_link'
+                            ] as string;
                             const html = `
                                 <div style="color:black;width:400px;">
+                                <a href="${datasetLink}" target="_blank">Data Source
                                     <img style="width:100%;" src="${imageLink}" alt="Plot of forecasted river conditions" />
+                                </a>
                                 </div>
                                 `;
                             persistentPopup

--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -442,7 +442,7 @@ export const getLayerConfig = (
                     'circle-stroke-color': '#000',
                     'circle-color': [
                         'step',
-                        ['get', 'esppavg'],
+                        ['get', 'latest_esppavg'],
                         '#d73027',
                         25,
                         '#f46d43',
@@ -596,7 +596,7 @@ export const getLayerHoverFunction = (
                                 'espname'
                             ] as string;
                             const average = Number(
-                                feature.properties['esppavg']
+                                feature.properties['latest_esppavg']
                             ).toFixed(1);
                             const html = `
                             <div>
@@ -767,7 +767,7 @@ export const getLayerMouseMoveFunction = (
                                 'espname'
                             ] as string;
                             const average = Number(
-                                feature.properties['esppavg']
+                                feature.properties['espplatest_esppavgavg']
                             ).toFixed(1);
                             const html = `
                                 <div>


### PR DESCRIPTION
In all the noaa forecasts to my understanding, the image displays the `esppavg` value on the latest forecast. As a result, in the backend I am able to have this as a static property in the geojson response. This makes it so the frontend can just switch to using this property and not need to do any transformation on the geojson