### PR TITLE
Feature: support for lines and polygons in edr layers

### DIFF
--- a/hub-ui/src/features/Legend/index.tsx
+++ b/hub-ui/src/features/Legend/index.tsx
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Fragment, useEffect } from "react";
-import { ColorInput, Divider, Group, Stack, Switch, Text } from "@mantine/core";
-import { useMap } from "@/contexts/MapContexts";
-import styles from "@/features/Legend/Legend.module.css";
-import { MAP_ID } from "@/features/Map/config";
-import mainManager from "@/managers/Main.init";
-import useMainStore from "@/stores/main";
-import useSessionStore from "@/stores/session";
-import { SessionState } from "@/stores/session/types";
+import { Fragment, useEffect } from 'react';
+import { ColorInput, Divider, Group, Stack, Switch, Text } from '@mantine/core';
+import { useMap } from '@/contexts/MapContexts';
+import styles from '@/features/Legend/Legend.module.css';
+import { MAP_ID } from '@/features/Map/config';
+import mainManager from '@/managers/Main.init';
+import useMainStore from '@/stores/main';
+import useSessionStore from '@/stores/session';
+import { SessionState } from '@/stores/session/types';
 
 const Legend: React.FC = () => {
   const { map } = useMap(MAP_ID);
@@ -19,115 +19,109 @@ const Legend: React.FC = () => {
   const legendEntries = useSessionStore((state) => state.legendEntries);
   const setLegendEntries = useSessionStore((state) => state.setLegendEntries);
 
-  const originalCollections = useMainStore(
-    (state) => state.originalCollections,
-  );
+  const originalCollections = useMainStore((state) => state.originalCollections);
 
   useEffect(() => {
     if (!map) {
       return;
     }
 
-    map.on("styledata", () => {
+    map.on('styledata', () => {
       const originalCollections = useMainStore.getState().originalCollections;
       const legendEntries = useSessionStore.getState().legendEntries;
 
       const layers = map.getStyle().layers;
-      const newLegendEntries: SessionState["legendEntries"] = [];
+      const newLegendEntries: SessionState['legendEntries'] = [];
+
       layers.forEach((layer) => {
         if (
-          layer.type === "circle" &&
-          originalCollections.some(
-            (collection) =>
-              mainManager.getLocationsLayerId(collection.id) === layer.id,
+          layer.type === 'circle' &&
+          originalCollections.some((collection) =>
+            Object.values(mainManager.getLocationsLayerIds(collection.id)).includes(layer.id)
           ) &&
           layer.paint
         ) {
-          const color = layer.paint["circle-color"];
-          if (typeof color === "string") {
+          const collection = originalCollections.find((collection) =>
+            Object.values(mainManager.getLocationsLayerIds(collection.id)).includes(layer.id)
+          );
+          const color = layer.paint['circle-color'];
+          if (collection && typeof color === 'string') {
             newLegendEntries.push({
-              layerId: layer.id,
-              color: color ?? "#000",
+              collectionId: collection.id,
+              color: color ?? '#000',
               visible:
-                legendEntries.find((entry) => entry.layerId === layer.id)
-                  ?.visible ?? true,
+                legendEntries.find((entry) => entry.collectionId === collection.id)?.visible ??
+                true,
             });
           }
         }
       });
+
       useSessionStore.getState().setLegendEntries(newLegendEntries);
     });
   }, [map]);
 
-  const getCollectionTitle = (layerId: string) => {
-    const collection = originalCollections.find(
-      (collection) =>
-        mainManager.getLocationsLayerId(collection.id) === layerId,
-    );
+  const getCollectionTitle = (collectionId: string) => {
+    const collection = originalCollections.find((collection) => collection.id === collectionId);
 
-    return collection?.title ?? layerId;
+    return collection?.title ?? collectionId;
   };
-  const handleColorChange = (color: string, layerId: string) => {
+  const handleColorChange = (color: string, collectionId: string) => {
+    const { pointLayerId, lineLayerId, fillLayerId } =
+      mainManager.getLocationsLayerIds(collectionId);
     if (map) {
-      map.setPaintProperty(layerId, "circle-color", color);
+      map.setPaintProperty(pointLayerId, 'circle-color', color);
+      map.setPaintProperty(lineLayerId, 'line-color', color);
+      map.setPaintProperty(fillLayerId, 'fill-color', color);
     }
 
-    const oldEntry = legendEntries.filter(
-      (entry) => entry.layerId === layerId,
-    )[0];
-    const newLegendEntries = legendEntries.filter(
-      (entry) => entry.layerId !== layerId,
-    );
+    const oldEntry = legendEntries.filter((entry) => entry.collectionId === collectionId)[0];
+    const newLegendEntries = legendEntries.filter((entry) => entry.collectionId !== collectionId);
 
     setLegendEntries([
       ...newLegendEntries,
       {
-        layerId,
+        collectionId,
         color,
         visible: oldEntry.visible,
       },
     ]);
   };
 
-  const handleVisibilityChange = (visible: boolean, layerId: string) => {
-    if (map) {
-      map.setLayoutProperty(
-        layerId,
-        "visibility",
-        visible ? "visible" : "none",
-      );
-    }
-
-    const oldEntry = legendEntries.filter(
-      (entry) => entry.layerId === layerId,
-    )[0];
-    const newLegendEntries = legendEntries.filter(
-      (entry) => entry.layerId !== layerId,
-    );
+  const handleVisibilityChange = (visible: boolean, collectionId: string) => {
+    const oldEntry = legendEntries.filter((entry) => entry.collectionId === collectionId)[0];
+    const newLegendEntries = legendEntries.filter((entry) => entry.collectionId !== collectionId);
 
     setLegendEntries([
       ...newLegendEntries,
       {
-        layerId,
+        collectionId,
         color: oldEntry.color,
         visible,
       },
     ]);
+    const { pointLayerId, lineLayerId, fillLayerId } =
+      mainManager.getLocationsLayerIds(collectionId);
+    if (map) {
+      map.setLayoutProperty(pointLayerId, 'visibility', visible ? 'visible' : 'none');
+      map.setLayoutProperty(lineLayerId, 'visibility', visible ? 'visible' : 'none');
+      map.setLayoutProperty(fillLayerId, 'visibility', visible ? 'visible' : 'none');
+    }
   };
 
   return (
     <Stack>
       {legendEntries
-        .sort((a, b) => a.layerId.localeCompare(b.layerId))
+        .sort((a, b) => a.collectionId.localeCompare(b.collectionId))
         .map((entry, index) => (
-          <Fragment key={`legend-entry-${entry.layerId}`}>
+          <Fragment key={`legend-entry-${entry.collectionId}`}>
             <Stack>
-              <Text>{getCollectionTitle(entry.layerId)}</Text>
+              <Text>{getCollectionTitle(entry.collectionId)}</Text>
               <Group justify="space-between" align="flex-end">
                 <ColorInput
-                  label="Location Points"
+                  label="Locations"
                   value={entry.color}
-                  onChange={(color) => handleColorChange(color, entry.layerId)}
+                  onChange={(color) => handleColorChange(color, entry.collectionId)}
                   className={styles.colorPicker}
                 />
                 <Switch
@@ -136,7 +130,7 @@ const Legend: React.FC = () => {
                   offLabel="OFF"
                   checked={entry.visible}
                   onChange={(event) =>
-                    handleVisibilityChange(event.target.checked, entry.layerId)
+                    handleVisibilityChange(event.target.checked, entry.collectionId)
                   }
                 />
               </Group>

--- a/hub-ui/src/features/Map/index.tsx
+++ b/hub-ui/src/features/Map/index.tsx
@@ -3,20 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useEffect, useRef, useState } from "react";
-import Map from "@/components/Map";
-import { basemaps } from "@/components/Map/consts";
-import CustomControl from "@/components/Map/tools/CustomControl";
-import { BasemapId } from "@/components/Map/types";
-import { useMap } from "@/contexts/MapContexts";
-import { layerDefinitions, MAP_ID } from "@/features/Map/config";
-import { sourceConfigs } from "@/features/Map/sources";
-import { MapButton as Legend } from "@/features/Map/Tools/Legend/Button";
-import { getCircleStrokeColor } from "@/features/Map/utils";
-import mainManager from "@/managers/Main.init";
-import useMainStore from "@/stores/main";
-import useSessionStore from "@/stores/session";
-import { groupLocationIdsByCollection } from "@/utils/groupLocationsByCollection";
+import { useEffect, useRef, useState } from 'react';
+import Map from '@/components/Map';
+import { basemaps } from '@/components/Map/consts';
+import CustomControl from '@/components/Map/tools/CustomControl';
+import { BasemapId } from '@/components/Map/types';
+import { useMap } from '@/contexts/MapContexts';
+import { layerDefinitions, MAP_ID } from '@/features/Map/config';
+import { sourceConfigs } from '@/features/Map/sources';
+import { MapButton as Legend } from '@/features/Map/Tools/Legend/Button';
+import { getSelectedColor } from '@/features/Map/utils';
+import mainManager from '@/managers/Main.init';
+import useMainStore from '@/stores/main';
+import useSessionStore from '@/stores/session';
+import { groupLocationIdsByCollection } from '@/utils/groupLocationsByCollection';
 
 const INITIAL_CENTER: [number, number] = [-98.5795, 39.8282];
 const INITIAL_ZOOM = 4;
@@ -72,7 +72,7 @@ const MainMap: React.FC<Props> = (props) => {
         {
           padding: 50,
           animate: false,
-        },
+        }
       );
       initialMapLoad.current = false;
     }
@@ -93,15 +93,16 @@ const MainMap: React.FC<Props> = (props) => {
 
     const locationsByCollection = groupLocationIdsByCollection(locations);
     collections.forEach((collection) => {
-      const layerId = mainManager.getLocationsLayerId(collection.id);
+      const { pointLayerId, lineLayerId } = mainManager.getLocationsLayerIds(collection.id);
 
       const locationIds = locationsByCollection[collection.id] ?? [];
-      if (map.getLayer(layerId)) {
-        map.setPaintProperty(
-          layerId,
-          "circle-stroke-color",
-          getCircleStrokeColor(locationIds),
-        );
+      let color;
+      if (map.getLayer(pointLayerId)) {
+        color = map.getPaintProperty(pointLayerId, 'circle-color') as string;
+        map.setPaintProperty(pointLayerId, 'circle-stroke-color', getSelectedColor(locationIds));
+      }
+      if (map.getLayer(lineLayerId)) {
+        map.setPaintProperty(lineLayerId, 'line-color', getSelectedColor(locationIds, color));
       }
     });
   }, [locations]);
@@ -161,7 +162,7 @@ const MainMap: React.FC<Props> = (props) => {
         layers={layerDefinitions}
         options={{
           style: basemaps[BasemapId.Streets],
-          projection: "mercator",
+          projection: 'mercator',
           center: INITIAL_CENTER,
           zoom: INITIAL_ZOOM,
           maxZoom: 20,
@@ -173,7 +174,7 @@ const MainMap: React.FC<Props> = (props) => {
         customControls={[
           {
             control: new CustomControl(<Legend />),
-            position: "top-right",
+            position: 'top-right',
           },
         ]}
       />

--- a/hub-ui/src/features/Map/utils.ts
+++ b/hub-ui/src/features/Map/utils.ts
@@ -3,50 +3,66 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ExpressionSpecification, LayerSpecification } from "mapbox-gl";
-import { LayerType } from "@/components/Map/types";
-import { Location } from "@/stores/main/types";
-import { getRandomHexColor } from "@/utils/hexColor";
+import { ExpressionSpecification, LayerSpecification } from 'mapbox-gl';
+import { LayerType } from '@/components/Map/types';
+import { Location } from '@/stores/main/types';
 
 export const getPointLayerDefinition = (
   layerId: string,
   sourceId: string,
+  color: string
 ): LayerSpecification => {
   return {
     id: layerId,
     type: LayerType.Circle,
     source: sourceId,
     paint: {
-      "circle-radius": 6,
-      "circle-color": getRandomHexColor(),
-      "circle-stroke-width": 2,
-      "circle-stroke-color": getCircleStrokeColor([]),
+      'circle-radius': 6,
+      'circle-color': color,
+      'circle-stroke-width': 2,
+      'circle-stroke-color': getSelectedColor([]),
     },
   };
 };
-
-export const getPolygonLayerDefinition = (
+export const getLineLayerDefinition = (
   layerId: string,
   sourceId: string,
+  color: string = '#000'
 ): LayerSpecification => {
   return {
     id: layerId,
     type: LayerType.Line,
     source: sourceId,
     layout: {
-      "line-cap": "round",
-      "line-join": "round",
+      'line-cap': 'round',
+      'line-join': 'round',
     },
     paint: {
-      "line-opacity": 1,
-      "line-color": "#000",
-      "line-width": 2,
+      'line-opacity': 1,
+      'line-color': color,
+      'line-width': 2,
+    },
+  };
+};
+export const getFillLayerDefinition = (
+  layerId: string,
+  sourceId: string,
+  color: string = '#000'
+): LayerSpecification => {
+  return {
+    id: layerId,
+    type: LayerType.Fill,
+    source: sourceId,
+    paint: {
+      'fill-opacity': 0.7,
+      'fill-color': color,
     },
   };
 };
 
-export const getCircleStrokeColor = (
-  locationIds: Array<Location["id"]>,
+export const getSelectedColor = (
+  locationIds: Array<Location['id']>,
+  originalColor: string = '#000'
 ): ExpressionSpecification => {
-  return ["case", ["in", ["id"], ["literal", locationIds]], "#FFF", "#000"];
+  return ['case', ['in', ['id'], ['literal', locationIds]], '#FFF', originalColor];
 };

--- a/hub-ui/src/features/Panel/Controls/ClearAllData.tsx
+++ b/hub-ui/src/features/Panel/Controls/ClearAllData.tsx
@@ -3,21 +3,20 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { useEffect, useState } from "react";
-import { Button, Tooltip } from "@mantine/core";
-import { useMap } from "@/contexts/MapContexts";
-import { MAP_ID } from "@/features/Map/config";
-import { useLoading } from "@/hooks/useLoading";
-import mainManager from "@/managers/Main.init";
-import useMainStore from "@/stores/main";
+import { useEffect, useState } from 'react';
+import { Button, Tooltip } from '@mantine/core';
+import { useMap } from '@/contexts/MapContexts';
+import { MAP_ID } from '@/features/Map/config';
+import { useLoading } from '@/hooks/useLoading';
+import mainManager from '@/managers/Main.init';
+import useMainStore from '@/stores/main';
 
 export const Reset: React.FC = () => {
   const hasGeographyFilter = useMainStore((state) => state.hasGeographyFilter);
 
   const [hasLocationsLoaded, setHasLocationsLoaded] = useState(false);
 
-  const { isLoadingGeography, isFetchingCollections, isFetchingLocations } =
-    useLoading();
+  const { isLoadingGeography, isFetchingCollections, isFetchingLocations } = useLoading();
 
   const { map } = useMap(MAP_ID);
 
@@ -26,35 +25,34 @@ export const Reset: React.FC = () => {
       return;
     }
 
-    map.on("styledata", () => {
+    map.on('styledata', () => {
       const collections = useMainStore.getState().collections;
       const layers = map.getStyle().layers;
       setHasLocationsLoaded(
         layers.some((layer) =>
-          collections.some(
-            (collection) =>
-              mainManager.getLocationsLayerId(collection.id) === layer.id,
-          ),
-        ),
+          collections.some((collection) =>
+            Object.values(mainManager.getLocationsLayerIds(collection.id)).includes(layer.id)
+          )
+        )
       );
     });
   }, [map]);
 
   const getLabel = () => {
     if (isLoadingGeography) {
-      return "Please wait for geography filter to load";
+      return 'Please wait for geography filter to load';
     }
 
     if (isFetchingCollections) {
-      return "Please wait for collections request to complete";
+      return 'Please wait for collections request to complete';
     }
 
     if (isFetchingLocations) {
-      return "Please wait for locations request to complete";
+      return 'Please wait for locations request to complete';
     }
 
     if (!hasLocationsLoaded && !hasGeographyFilter()) {
-      return "No locations or geography to clear";
+      return 'No locations or geography to clear';
     }
   };
 
@@ -69,11 +67,7 @@ export const Reset: React.FC = () => {
         </Button>
       ) : (
         <Tooltip label={getLabel()}>
-          <Button
-            data-disabled
-            onClick={(event) => event.preventDefault()}
-            color="red-rocks"
-          >
+          <Button data-disabled onClick={(event) => event.preventDefault()} color="red-rocks">
             Reset
           </Button>
         </Tooltip>

--- a/hub-ui/src/stores/session/types.ts
+++ b/hub-ui/src/stores/session/types.ts
@@ -4,9 +4,9 @@
  */
 
 export enum NotificationType {
-  Success = "success",
-  Error = "error",
-  Info = "info",
+  Success = 'success',
+  Error = 'error',
+  Info = 'info',
 }
 
 /**
@@ -20,14 +20,14 @@ export enum NotificationType {
  * @enum
  */
 export enum LoadingType {
-  Locations = "locations",
-  Collections = "collections",
-  Geography = "geography",
-  Data = "data",
+  Locations = 'locations',
+  Collections = 'collections',
+  Geography = 'geography',
+  Data = 'data',
 }
 
 export enum Tools {
-  Legend = "legend",
+  Legend = 'legend',
 }
 
 export type Notification = {
@@ -44,18 +44,16 @@ export type Loading = {
 };
 
 export type LegendEntry = {
-  layerId: string;
+  collectionId: string;
   color: string;
   visible: boolean;
 };
 
 export type SessionState = {
   legendEntries: LegendEntry[];
-  setLegendEntries: (legendEntries: SessionState["legendEntries"]) => void;
+  setLegendEntries: (legendEntries: SessionState['legendEntries']) => void;
   downloadModalOpen: boolean;
-  setDownloadModalOpen: (
-    downloadModalOpen: SessionState["downloadModalOpen"],
-  ) => void;
+  setDownloadModalOpen: (downloadModalOpen: SessionState['downloadModalOpen']) => void;
   tools: {
     [Tools.Legend]: boolean;
   };


### PR DESCRIPTION
### **Description:**
Added support for lines and polygons in the hub.

### **To Test**
1. RISE has lines & polygons as well as points
2. Add collection without any geography filters
3. Clicking a location should add it to the downloadable selection
4. Clicking on a point above the geometry for a separate location should only select that point
5. Filter by a geographic filter on a collection
6. Change colors, toggle visibility
