### PR TITLE
Hotfix limit

### DIFF
--- a/dashboard-ui/src/features/Reservior/Chart/index.tsx
+++ b/dashboard-ui/src/features/Reservior/Chart/index.tsx
@@ -73,6 +73,7 @@ export const Chart: React.FC<Props> = (props) => {
                         signal: controller.current.signal,
                         params: {
                             limit: dateRange.days,
+                            f: 'json',
                             ...config.params,
                             datetime: dateRange.startDate + '/' + '..',
                         },

--- a/dashboard-ui/src/features/Reservior/Chart/index.tsx
+++ b/dashboard-ui/src/features/Reservior/Chart/index.tsx
@@ -72,9 +72,9 @@ export const Chart: React.FC<Props> = (props) => {
                     {
                         signal: controller.current.signal,
                         params: {
+                            limit: dateRange.days,
                             ...config.params,
                             datetime: dateRange.startDate + '/' + '..',
-                            limit: dateRange.days
                         },
                     }
                 );


### PR DESCRIPTION
For some reason having the limit at the end of the query string causes a 400 error