### PR TITLE
Remove failing assertion in NOAA due to change in upstream API

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "module": "uvicorn",
       "args": ["pygeoapi.starlette_app:APP", "--reload", "--port", "5005"],
       "env": {
-        "PYGEOAPI_CONFIG": "${workspaceFolder}/pygeoapi-deployment/pygeoapi.config.yml",
+        "PYGEOAPI_CONFIG": "${workspaceFolder}/pygeoapi.config.yml",
         "PYGEOAPI_OPENAPI": "${workspaceFolder}/local.openapi.yml"
       },
       "autoStartBrowser": true

--- a/packages/noaa_rfc/src/noaa_rfc/lib/forecast.py
+++ b/packages/noaa_rfc/src/noaa_rfc/lib/forecast.py
@@ -185,15 +185,9 @@ class ForecastCollection(LocationCollectionProtocol):
 
         assert len(results) >= 10
 
-        assert any([result["espid"][0] == "BTYO3" for result in results]), (
-            "A station from the California basin appears to be missing"
-        )
-
         # Process results using data2obj
         serialized = [ForecastData.model_validate(res) for res in results]
-        assert any([result.espid[0] == "BTYO3" for result in serialized]), (
-            "A station from the California basin appears to be missing after serializing to pydantic"
-        )
+
         return serialized
 
     def __init__(self):


### PR DESCRIPTION
Currently this is failing

https://api.wwdh.internetofwater.app/collections/noaa-rfc/items/DOLU1

This failure is due to 

```
  File "/opt/pygeoapi/packages/noaa_rfc/src/noaa_rfc/lib/forecast.py", line 188, in _get_data
    assert any([result["espid"][0] == "BTYO3" for result in results]), (
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: A station from the California basin appears to be missing"
```

This wasn't previously failing. It seems that NOAA removed a station. As such, I have removed the assertion. 

It is important to note that this may require us to recrawl NOAA since otherwise we may have stations that no longer exist.