### PR TITLE
Comment out USGS Sensorthings

### DIFF
--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -154,7 +154,10 @@ resources:
       - NRCS
     keywords:
       - open data
-    extents: *default-extent
+    extents: &default-extent
+      spatial:
+        bbox: [-170, 15, -51, 72]
+        crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
     providers:
       - type: edr
         name: awdb_forecasts.awdb_forecasts_edr.AwdbForecastsEDRProvider


### PR DESCRIPTION
USGS Sensorthings appears to have been taken down, thus this needs to be commented out else it will prevent us from deploying new containers since pygeoapi cant generate the openapi document