### PR TITLE
Bundle json in rise for it can be used in AWO

### DIFF
--- a/packages/rise/pyproject.toml
+++ b/packages/rise/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["rise"]
 
-force-include = { "rise/generated/Reservoirs_and_Capacity_Data.json" = "rise/generated/Reservoirs_and_Capacity_Data.json" }
+force-include = { "generated/Reservoirs_and_Capacity_Data.json" = "generated/Reservoirs_and_Capacity_Data.json" }
 
 artifacts = [
     "*.json"


### PR DESCRIPTION
In order to reuse RISE in other integrations it needs to have the associated metadata json file bundled with it.