### PR TITLE
Switch USACE parameters to be queried and return the same names

### DIFF
--- a/packages/usace/usace/lib/locations_collection.py
+++ b/packages/usace/usace/lib/locations_collection.py
@@ -368,10 +368,10 @@ class CovjsonBuilder(CovjsonBuilderProtocol):
         param = Parameter(
             type="Parameter",
             unit=Unit(symbol=datastream.unit),
-            id=datastream.tsid,
+            id=datastream.label,
             observedProperty=ObservedProperty(
                 label={"en": datastream.parameter},
-                id=datastream.tsid,
+                id=datastream.label,
                 description={"en": datastream.unit_long_name},
             ),
         )
@@ -410,7 +410,7 @@ class CovjsonBuilder(CovjsonBuilderProtocol):
                 ],
             ),
             ranges={
-                datastream.tsid: NdArrayFloat(
+                datastream.label: NdArrayFloat(
                     shape=[len(datastream.results.values)],
                     values=list[float | None](values),
                     axisNames=["t"],
@@ -432,7 +432,7 @@ class CovjsonBuilder(CovjsonBuilderProtocol):
                 longitude, latitude = loc.geometry.coordinates
                 cov = self._generate_coverage(param, longitude, latitude)
                 coverages.append(cov)
-                parameters[param.tsid] = self._generate_parameter(param)
+                parameters[param.label] = self._generate_parameter(param)
 
         covCol = CoverageCollection(
             coverages=coverages,

--- a/packages/usace/usace/lib/types/geojson_response.py
+++ b/packages/usace/usace/lib/types/geojson_response.py
@@ -35,7 +35,7 @@ class TimeseriesParameter(BaseModel):
 
         url = f"https://water.usace.army.mil/cda/reporting/providers/{office.lower()}/timeseries?name={self.tsid}&begin={start_date}&end={end_date}"
         result = await RedisCache().get_or_fetch_json(url)
-        assert result
+        assert result, f"{url} did not return any results"
         return ResultCollection(**result)
 
     async def fill_results(self, office: str, start_date: str, end_date: str):

--- a/packages/usace/usace/usace_edr_test.py
+++ b/packages/usace/usace/usace_edr_test.py
@@ -17,12 +17,16 @@ def test_usace_decode_param():
     p = USACEEDRProvider(provider_def)
     result = p.locations(
         location_id="2796555126",
-        select_properties=["Stage"],
+        select_properties=["Stage Tailwater"],
         datetime_="2025-01-01/..",
     )
     assert result and "coverages" in result
     assert len(result["coverages"]) == 1, (
         "There should be one coverage for this location after filtering out the others"
+    )
+    assert "parameters" in result
+    assert "Stage Tailwater" in result["parameters"], (
+        "Expected to find the filtered parameter with the same name in the parameters list"
     )
 
     with pytest.raises(ProviderNoDataError):


### PR DESCRIPTION
usace locations have both a natural language label and a tsid

```
        {
          "slug": "stor.spillway crest",
          "label": "Spillway Crest",
          "parameter": "Stor",
          "base_parameter": "Stor",
          "tsid": "MCN.Stor.Inst.0.Spillway Crest",
          "latest_value": 206400,
          "units": "ac-ft",
          "units_long_name": "Acre-feet"
        },
```

this PR switches from using tsid to label consistently in the covjson.

there is a small chance there may be duplicates on certain locations since a location could theoretically have the same parameter but different units and thus different tsids. I haven't explicitly seen this yet though so I think we are ok.


example output now
<img width="1925" height="927" alt="image" src="https://github.com/user-attachments/assets/7bb4d040-d4dc-4950-80dd-96cb9ea25182" />

