### PR TITLE
Change RISE values to be oldest to newest

### DIFF
--- a/packages/rise/rise/lib/helpers.py
+++ b/packages/rise/rise/lib/helpers.py
@@ -7,6 +7,8 @@ from typing import Optional
 
 from typing import Dict
 
+import urllib.parse
+
 
 def get_reservoir_capacity_json_path():
     """
@@ -69,7 +71,11 @@ def get_trailing_id(url: str) -> str:
 def getResultUrlFromCatalogUrl(url: str, datetime_: Optional[str]) -> str:
     """Create the result url given a catalog item url and the datetime we want to filter by"""
     OLDEST_TO_NEWEST = "asc"
-    base = f"https://data.usbr.gov/rise/api/result?order[dateTime]={OLDEST_TO_NEWEST}&itemId={get_trailing_id(url)}"
+    # this param needs to be url encoded; if we don't
+    # do it here, the http client will do it later anyways,
+    # but it is helpful for clarity / debugging to do it here
+    orderParamEncoded = urllib.parse.quote("order[dateTime]")
+    base = f"https://data.usbr.gov/rise/api/result?{orderParamEncoded}={OLDEST_TO_NEWEST}&itemId={get_trailing_id(url)}"
 
     if datetime_:
         parsed_date = datetime_.split("/")


### PR DESCRIPTION
By default RISE orders from newest to oldest. Most EDR endpoints we have order from oldest to newest. This PR changes RISE to be oldest to newest so it is consistent across our API.

http://localhost:5005/collections/rise-edr/locations/393?datetime=2022-01-01/..&f=json

```
  "coverages":[
        {
            "type":"Coverage",
            "domainType":"PointSeries",
            "domain":{
                "type":"Domain",
                "axes":{
                    "x":{
                        "values":[
                            -111.30332
                        ]
                    },
                    "y":{
                        "values":[
                            37.05778
                        ]
                    },
                    "t":{
                        "values":[
                            "2022-01-01T07:00:00+00:00",
                            "2022-01-02T07:00:00+00:00",
                            "2022-01-03T07:00:00+00:00",
                            "2022-01-04T07:00:00+00:00",
                            "2022-01-05T07:00:00+00:00",
                            "2022-01-06T07:00:00+00:00",
                            "2022-01-07T07:00:00+00:00",
                            "2022-01-08T07:00:00+00:00",
                            "2022-01-09T07:00:00+00:00",
                            "2022-01-10T07:00:00+00:00",
                            "2022-01-11T07:00:00+00:00",
                            "2022-01-12T07:00:00+00:00
```