### PR TITLE
fix: typo in README (Wester --> Western)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Western Water Datahub
 
-The Wester Water Datahub (WWDH) is an implementation of the [OGC API](https://ogcapi.ogc.org/) suite of standards, enabling access to water data from various sources through a unified interface. It is designed to enhance data interoperability, accessibility, and discoverability across multiple water data platforms.
+The Western Water Datahub (WWDH) is an implementation of the [OGC API](https://ogcapi.ogc.org/) suite of standards, enabling access to water data from various sources through a unified interface. It is designed to enhance data interoperability, accessibility, and discoverability across multiple water data platforms.
 
 This project is a collaboration between the United States Beaureu of Reclamation, the Center for Geospatial Solutions, and Wester States Water Council.
 


### PR DESCRIPTION
Fixes a typo in the README from `Wester` to `Western`.