### PR TITLE
fix: typos in README (Beaureu --> Bureau, Wester --> Western)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Western Water Datahub (WWDH) is an implementation of the [OGC API](https://ogcapi.ogc.org/) suite of standards, enabling access to water data from various sources through a unified interface. It is designed to enhance data interoperability, accessibility, and discoverability across multiple water data platforms.
 
-This project is a collaboration between the United States Beaureu of Reclamation, the Center for Geospatial Solutions, and Wester States Water Council.
+This project is a collaboration between the United States Bureau of Reclamation, the Center for Geospatial Solutions, and Western States Water Council.
 
 ## Source Systems
 


### PR DESCRIPTION
Fixing a few more typos in the README.