### PR TITLE
Remove zero padded huc labels

### DIFF
--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -891,7 +891,7 @@ export const getLayerHoverFunction = (
                             const html = `
                                 <div>
                                   <strong>${name}</strong><br/>
-                                  <p>Huc06: ${huc06}</p>
+                                  <p>Huc6: ${huc06}</p>
                                   <p>Change in Snow Water Equivalent: ${swe}%</p>
                                 </div>
                                 `;
@@ -1233,7 +1233,7 @@ export const getLayerMouseMoveFunction = (
                             const html = `
                             <div>
                               <strong>${name}</strong><br/>
-                              <p>Huc06: ${huc06}</p>
+                              <p>Huc6: ${huc06}</p>
                               <p>Change in Snow Water Equivalent: ${swe}%</p>
                             </div>
                             `;

--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -891,7 +891,7 @@ export const getLayerHoverFunction = (
                             const html = `
                                 <div>
                                   <strong>${name}</strong><br/>
-                                  <p>Huc6: ${huc06}</p>
+                                  <p>HUC6: ${huc06}</p>
                                   <p>Change in Snow Water Equivalent: ${swe}%</p>
                                 </div>
                                 `;
@@ -1233,7 +1233,7 @@ export const getLayerMouseMoveFunction = (
                             const html = `
                             <div>
                               <strong>${name}</strong><br/>
-                              <p>Huc6: ${huc06}</p>
+                              <p>HUC6: ${huc06}</p>
                               <p>Change in Snow Water Equivalent: ${swe}%</p>
                             </div>
                             `;

--- a/dashboard-ui/src/features/MapTools/Legend/Content.tsx
+++ b/dashboard-ui/src/features/MapTools/Legend/Content.tsx
@@ -92,7 +92,7 @@ export const Content: React.FC<Props> = (props) => {
                         <Line color="#54278f" />
                     </Box>
                     <Title order={4} size="h6">
-                        Basin (HUC02) Boundaries
+                        Basin (HUC2) Boundaries
                     </Title>
                 </Group>
             )}

--- a/dashboard-ui/src/features/ReferenceData/index.tsx
+++ b/dashboard-ui/src/features/ReferenceData/index.tsx
@@ -247,7 +247,7 @@ const ReferenceData: React.FC = () => {
                     />
                     <Entry
                         layerId={LayerId.BasinsReference}
-                        label="Show Basin (HUC02) Boundaries"
+                        label="Show Basin (HUC2) Boundaries"
                         onClick={handleBasinsReferenceChange}
                         toggleableLayers={toggleableLayers}
                         links={false}

--- a/dashboard-ui/src/features/Reservoirs/Filter/Selectors/BoundingGeography.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/Selectors/BoundingGeography.tsx
@@ -60,7 +60,7 @@ const data = [
     },
     {
         value: BoundingGeographyLevel.Basin,
-        label: 'Basin (HUC02)',
+        label: 'Basin (HUC2)',
     },
     {
         value: BoundingGeographyLevel.State,

--- a/pygeoapi.config.yml
+++ b/pygeoapi.config.yml
@@ -168,8 +168,8 @@ resources:
 
   snotel-huc06-means:
     type: collection
-    title: USDA Snotel Snow Water Equivalent Aggregated by HUC06
-    description: provides snow water equivalent (swe) data from SNOTEL aggregated by HUC06 watershed. Each feature contains one average for the entire HUC06; this is calculated by taking the latest swe value, dividing it by the 30 year average swe value on for the same day, and multiplying it by 100.
+    title: USDA Snotel Snow Water Equivalent Aggregated by HUC6
+    description: provides snow water equivalent (swe) data from SNOTEL aggregated by HUC6 watershed. Each feature contains one average for the entire HUC6; this is calculated by taking the latest swe value, dividing it by the 30 year average swe value on for the same day, and multiplying it by 100.
     provider-name:
       - DOA
       - USDA


### PR DESCRIPTION
Remove zero padded huc labels (Comment 19, 12). This leaves the underlying source preserving the 0 padded and just changes the labels presented to the users