### PR TITLE
Fix: Change source layer for fetching snotel links

### DIFF
--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -236,6 +236,8 @@ export const getLayerName = (layerId: LayerId | SubLayerId): string => {
             return 'Regions';
         case LayerId.Snotel:
             return 'NRCS SNOTEL Snow Water Equivalent (% of Median)';
+        case LayerId.SnotelHucSixMeans:
+            return 'NRCS SNOTEL Snow Water Equivalent (% of Median)';
         case LayerId.NOAARiverForecast:
             return 'NOAA RFC Seasonal Water Supply Forecasts (% of Average)';
         case LayerId.USDroughtMonitor:
@@ -755,6 +757,7 @@ export const getLayerHoverFunction = (
                 };
             case LayerId.TeacupEDRReservoirs:
                 return (e) => {
+                    hoverPopup.remove();
                     const feature = e.features?.[0] as Feature<Point>;
                     if (feature) {
                         useSessionStore.getState().setHighlight({
@@ -867,7 +870,7 @@ export const getLayerHoverFunction = (
                         {
                             layers: [
                                 LayerId.NOAARiverForecast,
-                                LayerId.ResvizEDRReservoirs,
+                                LayerId.TeacupEDRReservoirs,
                             ],
                         }
                     );
@@ -1099,6 +1102,7 @@ export const getLayerMouseMoveFunction = (
                 };
             case LayerId.TeacupEDRReservoirs:
                 return (e) => {
+                    hoverPopup.remove();
                     const feature = e.features?.[0] as Feature<Point>;
                     if (feature) {
                         useSessionStore.getState().setHighlight({
@@ -1209,7 +1213,7 @@ export const getLayerMouseMoveFunction = (
                         {
                             layers: [
                                 LayerId.NOAARiverForecast,
-                                LayerId.ResvizEDRReservoirs,
+                                LayerId.TeacupEDRReservoirs,
                             ],
                         }
                     );

--- a/dashboard-ui/src/features/MapTools/Legend/consts.ts
+++ b/dashboard-ui/src/features/MapTools/Legend/consts.ts
@@ -9,7 +9,7 @@ import { LayerType } from '@/components/Map/types';
 
 export const entries: TEntry[] = [
     {
-        id: LayerId.Snotel,
+        id: LayerId.SnotelHucSixMeans,
         type: LayerType.Fill,
         items: [
             {

--- a/dashboard-ui/src/features/ReferenceData/index.tsx
+++ b/dashboard-ui/src/features/ReferenceData/index.tsx
@@ -103,7 +103,6 @@ const ReferenceData: React.FC = () => {
         updateNOAARFC(showNOAARFC, map);
 
         setToggleableLayers(LayerId.NOAARiverForecast, showNOAARFC);
-        // setShowNOAARFC(showNOAARFC);
     };
 
     const handleSnotelChange = (showSnotel: boolean) => {
@@ -113,8 +112,7 @@ const ReferenceData: React.FC = () => {
 
         updateSnotel(showSnotel, map);
 
-        setToggleableLayers(LayerId.Snotel, showSnotel);
-        // setShowSnotel(showSnotel);
+        setToggleableLayers(LayerId.SnotelHucSixMeans, showSnotel);
     };
 
     const handleRegionsReferenceChange = (showRegionsReference: boolean) => {
@@ -193,8 +191,8 @@ const ReferenceData: React.FC = () => {
                         toggleableLayers={toggleableLayers}
                     />
                     <Entry
-                        layerId={LayerId.Snotel}
-                        label={`Show ${getLayerName(LayerId.Snotel)}`}
+                        layerId={LayerId.SnotelHucSixMeans}
+                        label={`Show ${getLayerName(LayerId.SnotelHucSixMeans)}`}
                         onClick={handleSnotelChange}
                         toggleableLayers={toggleableLayers}
                     />

--- a/dashboard-ui/src/stores/main/index.ts
+++ b/dashboard-ui/src/stores/main/index.ts
@@ -50,7 +50,7 @@ export interface MainState {
     setChartUpdate: (chartUpdate: MainState['chartUpdate']) => void;
     // Reference data layers that can be toggled on/off
     toggleableLayers: {
-        [LayerId.Snotel]: boolean;
+        [LayerId.SnotelHucSixMeans]: boolean;
         [LayerId.NOAARiverForecast]: boolean;
         [LayerId.USDroughtMonitor]: boolean;
         [LayerId.NOAAPrecipSixToTen]: boolean;
@@ -96,7 +96,7 @@ const useMainStore = create<MainState>()((set) => ({
     chartUpdate: 0,
     setChartUpdate: (chartUpdate) => set({ chartUpdate }),
     toggleableLayers: {
-        [LayerId.Snotel]: false,
+        [LayerId.SnotelHucSixMeans]: false,
         [LayerId.NOAARiverForecast]: false,
         [LayerId.USDroughtMonitor]: true,
         [LayerId.NOAAPrecipSixToTen]: false,


### PR DESCRIPTION
### **Description:**
Pointing the reference data section to the Huc6 means layer in order to fetch the correct documentation.

### **Acceptance Criteria**
- [ ] Docs point to correct site
    - [ ] [Source](https://nwcc-apps.sc.egov.usda.gov/imap/#version=2&elements=&networks=!&states=!&counties=!&hucs=&minElevation=&maxElevation=&elementSelectType=any&activeOnly=true&activeForecastPointsOnly=true&hucLabels=false&hucIdLabels=false&hucParameterLabels=true&stationLabels=&overlays=&hucOverlays=&basinOpacity=75&basinNoDataOpacity=25&basemapOpacity=100&maskOpacity=0&mode=stations&openSections=networks&controlsOpen=true&popup=&popupMulti=&popupBasin=&base=esriNgwm&displayType=basinstation&basinType=6&dataElement=WTEQ&depth=-8&parameter=PCTMED&frequency=DAILY&duration=I&customDuration=&dayPart=E&year=2026&month=5&day=5&monthPart=E&forecastPubMonth=5&forecastPubDay=1&forecastExceedance=50&useMixedPast=true&seqColor=1&divColor=7&scaleType=D&scaleMin=&scaleMax=&referencePeriodType=POR&referenceBegin=1991&referenceEnd=2020&minimumYears=20&hucAssociations=true&lat=42.300&lon=-114.300&zoom=4.5)
    - [ ] [Methodology](https://github.com/internetofwater/Western-Water-Datahub/tree/main/packages/snotel_means)
- [ ]  NRCS SNOTEL Snow Water Equivalent (% of Median) layer can be toggled off and on without issue
- [ ] Popup fetches correct information