### PR TITLE
Add Unit information to ontology

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1481,7 +1481,7 @@ wheels = [
 [[package]]
 name = "pygeoapi"
 version = "0.24.dev0"
-source = { git = "https://github.com/internetofwater/pygeoapi.git?rev=dev#65c684f418f0c41625801bb2d4cbfe6013f7b2ac" }
+source = { git = "https://github.com/internetofwater/pygeoapi.git?rev=dev#b1a4715e9339f08a5fc1db38dd115b4ae3fb37cd" }
 dependencies = [
     { name = "babel" },
     { name = "click" },


### PR DESCRIPTION
- Update ontology to include additional QUDT information (file is much larger now that we cant drop QUDT information)
- Bump pygeoapi branch to include version with parameter_unit handling