### PR TITLE
Update pygeoapi version

### DIFF
--- a/packages/teacup/teacup/lib.py
+++ b/packages/teacup/teacup/lib.py
@@ -208,9 +208,10 @@ def run_location_load(force_clean_layer=False) -> None:
         row["source_uri"] = get_source_url(source_name, source, pref_name)
 
         # Clean Total Capacity (cast to float)
-        row["total_capacity"] = float(
-            row["total_capacity"].replace(",", "").replace("--", "NaN")
-        )
+        try:
+            row["total_capacity"] = float(row["total_capacity"].replace(",", ""))
+        except (ValueError, AttributeError):
+            row["total_capacity"] = None
 
         # Shorten Column Names
         row["map_label"] = row.pop("preferred_label_for_map_and_table")

--- a/uv.lock
+++ b/uv.lock
@@ -1481,7 +1481,7 @@ wheels = [
 [[package]]
 name = "pygeoapi"
 version = "0.24.dev0"
-source = { git = "https://github.com/internetofwater/pygeoapi.git?rev=dev#fdf706ae2a17e0983335f344432b26f2685bcdf6" }
+source = { git = "https://github.com/internetofwater/pygeoapi.git?rev=dev#c90e8a11c12bc1a38b2f7a90a6cfe2b38ad132f3" }
 dependencies = [
     { name = "babel" },
     { name = "click" },


### PR DESCRIPTION
With https://github.com/internetofwater/pygeoapi/pull/60
- Update pygeoapi remote to ontology mapping that replaces `parameter.name` in addition to `parameter.observedProperty.label.en`.
- Add Parameter label and parameter symbol from ontology layer
(Unrelated to pygeoapi)
- prevent NaN from entering teacup locations