### PR TITLE
Feature: Add map scale to report legend

### DIFF
--- a/dashboard-ui/src/services/report/report.service.ts
+++ b/dashboard-ui/src/services/report/report.service.ts
@@ -18,7 +18,7 @@ import {
     calculateYPositionContructor,
 } from '@/features/Reservior/TeacupDiagram/utils';
 import { Feature, GeoJsonProperties, Point } from 'geojson';
-import { Map } from 'mapbox-gl';
+import { Map, ScaleControl } from 'mapbox-gl';
 import { bbox, featureCollection } from '@turf/turf';
 import dayjs from 'dayjs';
 import { OrganizedProperties } from '@/features/Reservoirs/types';
@@ -659,11 +659,21 @@ export class ReportService {
         context.drawImage(mapCanvas, 0, 0);
         context.restore();
 
+        const legendPosition = { x: 1297, y: 519 };
+
         if (reportLegend) {
             context.drawImage(
                 reportLegend,
-                1297,
-                519,
+                legendPosition.x,
+                legendPosition.y,
+                legendWidth,
+                legendHeight
+            );
+
+            this.drawScale(
+                map,
+                context,
+                legendPosition,
                 legendWidth,
                 legendHeight
             );
@@ -693,5 +703,65 @@ export class ReportService {
             }, 'image/png');
         };
         img.src = url;
+    }
+
+    private drawScale(
+        map: Map,
+        context: OffscreenCanvasRenderingContext2D,
+        legendPosition: { x: number; y: number },
+        legendWidth: number,
+        legendHeight: number
+    ) {
+        // Add scale control
+        map.addControl(new ScaleControl());
+
+        // Get scale HTML element
+        const scaleElement = map
+            .getContainer()
+            .querySelector('.mapboxgl-ctrl-scale');
+
+        // No-op if scale HTML element is missing
+        if (!scaleElement) {
+            console.error('Failed to add map scale');
+            return;
+        }
+
+        const scaleWidth = scaleElement.clientWidth;
+        const scaleLabel = scaleElement.textContent;
+
+        const scaleOffsetY = 15;
+        const labelOffset = 15;
+
+        const minX = legendPosition.x + legendWidth / 2 - scaleWidth / 2;
+        const maxX = minX + scaleWidth;
+        const midX = (minX + maxX) / 2;
+
+        const midY = legendPosition.y + legendHeight - scaleOffsetY;
+
+        const tickHeight = 5;
+
+        context.strokeStyle = 'black';
+        context.lineWidth = 2;
+
+        // Draw lines
+        context.beginPath();
+        context.moveTo(minX, midY);
+        context.lineTo(maxX, midY);
+
+        context.moveTo(minX, midY - tickHeight);
+        context.lineTo(minX, midY + tickHeight);
+
+        context.moveTo(maxX, midY - tickHeight);
+        context.lineTo(maxX, midY + tickHeight);
+
+        context.stroke();
+
+        // Draw label
+        context.font = '10px sans-serif';
+        context.fillStyle = 'black';
+        context.textAlign = 'center';
+        context.textBaseline = 'top';
+
+        context.fillText(scaleLabel, midX, midY - labelOffset);
     }
 }

--- a/dashboard-ui/src/services/report/report.service.ts
+++ b/dashboard-ui/src/services/report/report.service.ts
@@ -707,7 +707,7 @@ export class ReportService {
 
     private drawScale(
         map: Map,
-        context: OffscreenCanvasRenderingContext2D,
+        context: CanvasRenderingContext2D,
         legendPosition: { x: number; y: number },
         legendWidth: number,
         legendHeight: number
@@ -722,6 +722,7 @@ export class ReportService {
 
         // No-op if scale HTML element is missing
         if (!scaleElement) {
+            // eslint-disable-next-line no-console
             console.error('Failed to add map scale');
             return;
         }

--- a/dashboard-ui/src/services/report/report.service.ts
+++ b/dashboard-ui/src/services/report/report.service.ts
@@ -763,6 +763,8 @@ export class ReportService {
         context.textAlign = 'center';
         context.textBaseline = 'top';
 
-        context.fillText(scaleLabel, midX, midY - labelOffset);
+        if (scaleLabel) {
+            context.fillText(scaleLabel, midX, midY - labelOffset);
+        }
     }
 }


### PR DESCRIPTION
**Description**
This update adds a simple map scale to report legend.

**Acceptance Criteria**
- Map scale bar appears in the report legend, positioned at the bottom-center.
- Map scale bar width and text update with map zoom level.
- Map scale bar renders in the correct position across all map legends.

Layer | Screenshot
--- | ---
Drought (zoomed out) | <img width="1600" height="900" alt="drought-zoomed-out" src="https://github.com/user-attachments/assets/d21819d3-ef59-4f9c-abab-5f7351491319" />
Drought (zoomed in) | <img width="1600" height="900" alt="drought-zoomed-in" src="https://github.com/user-attachments/assets/67598f53-a300-4ccf-a3b5-aa3c25949cbc" />
Precipitation | <img width="1600" height="900" alt="precipitation" src="https://github.com/user-attachments/assets/e07cbdbf-711d-4e3f-b64e-1e4bf6d38f95" />
Temperature | <img width="1600" height="900" alt="temperature" src="https://github.com/user-attachments/assets/79235bb3-1e17-422f-91ee-544bf59f9cdb" />
None | <img width="1600" height="900" alt="none" src="https://github.com/user-attachments/assets/08419277-562a-4da6-ad46-33174b62bbc0" />