### PR TITLE
Feature: Adjust report aspect ratio

### DIFF
--- a/dashboard-ui/src/features/Reservoirs/Report/index.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Report/index.tsx
@@ -143,8 +143,8 @@ const Report: React.FC<Props> = (props) => {
         document.body.appendChild(hidden);
 
         container.current = document.createElement('div');
-        container.current.style.width = '1600px';
-        container.current.style.height = '900px';
+        container.current.style.width = '1650px';
+        container.current.style.height = '1275px';
         hidden.appendChild(container.current);
         cloneMap.current = new Map({
             accessToken: accessToken,

--- a/dashboard-ui/src/features/Reservoirs/Report/index.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Report/index.tsx
@@ -27,7 +27,11 @@ import { OrganizedProperties } from '@/features/Reservoirs/types';
 import { formatOptions } from '@/features/Reservoirs/Filter/Selectors/utils';
 import { useLoading } from '@/hooks/useLoading';
 import Select from '@/components/Select';
-import { MAX_POSITIONS } from '@/services/report/report.consts';
+import {
+    MAP_CONTAINER_HEIGHT,
+    MAP_CONTAINER_WIDTH,
+    MAX_POSITIONS,
+} from '@/services/report/report.consts';
 import { getKey } from '@/features/Reservoirs/utils';
 
 type Props = {
@@ -143,8 +147,8 @@ const Report: React.FC<Props> = (props) => {
         document.body.appendChild(hidden);
 
         container.current = document.createElement('div');
-        container.current.style.width = '1650px';
-        container.current.style.height = '1275px';
+        container.current.style.width = `${MAP_CONTAINER_WIDTH}px`;
+        container.current.style.height = `${MAP_CONTAINER_HEIGHT}px`;
         hidden.appendChild(container.current);
         cloneMap.current = new Map({
             accessToken: accessToken,

--- a/dashboard-ui/src/services/report/report.consts.ts
+++ b/dashboard-ui/src/services/report/report.consts.ts
@@ -47,26 +47,34 @@
 //     { x: 60, y: 240 }, // Top left
 // ];
 
+const OFFSET_X = 50;
+const OFFSET_Y = 25;
+
+const WIDTH_X = 1650 / 6; // 6 across 1650px map canvas width
+const WIDTH_Y = 1275 / 5; // 5 across 1275px map canvas height
+
 export const RESERVOIR_POSITIONS = [
     // Top
-    { x: 60, y: 20 },
-    { x: 310, y: 20 },
-    { x: 560, y: 20 },
-    { x: 810, y: 20 },
-    { x: 1060, y: 20 },
-    // { x: 1310, y: 20 }, // Top Right
-    { x: 1310, y: 20 }, // Top Right
-    // Right most
-    { x: 1400, y: 250 },
+    { x: OFFSET_X + 0 * WIDTH_X, y: OFFSET_Y },
+    { x: OFFSET_X + 1 * WIDTH_X, y: OFFSET_Y },
+    { x: OFFSET_X + 2 * WIDTH_X, y: OFFSET_Y },
+    { x: OFFSET_X + 3 * WIDTH_X, y: OFFSET_Y },
+    { x: OFFSET_X + 4 * WIDTH_X, y: OFFSET_Y },
+    { x: OFFSET_X + 5 * WIDTH_X, y: OFFSET_Y },
+
+    // Right
+    { x: OFFSET_X + 5 * WIDTH_X, y: OFFSET_Y + 1 * WIDTH_Y },
+
+    // Left
+    { x: OFFSET_X, y: OFFSET_Y + 1 * WIDTH_Y },
+    { x: OFFSET_X, y: OFFSET_Y + 2 * WIDTH_Y },
+    { x: OFFSET_X, y: OFFSET_Y + 3 * WIDTH_Y },
+    { x: OFFSET_X, y: OFFSET_Y + 4 * WIDTH_Y },
+
     // Bottom
-    { x: 1050, y: 675 },
-    { x: 800, y: 675 },
-    { x: 550, y: 675 },
-    { x: 300, y: 675 },
-    // left
-    { x: 60, y: 675 },
-    { x: 60, y: 460 },
-    { x: 60, y: 240 }, // Top left
+    { x: OFFSET_X + 1 * WIDTH_X, y: OFFSET_Y + 4 * WIDTH_Y },
+    { x: OFFSET_X + 2 * WIDTH_X, y: OFFSET_Y + 4 * WIDTH_Y },
+    { x: OFFSET_X + 3 * WIDTH_X, y: OFFSET_Y + 4 * WIDTH_Y },
 ];
 
 export const MAX_POSITIONS = RESERVOIR_POSITIONS.length;

--- a/dashboard-ui/src/services/report/report.consts.ts
+++ b/dashboard-ui/src/services/report/report.consts.ts
@@ -47,11 +47,16 @@
 //     { x: 60, y: 240 }, // Top left
 // ];
 
+// Aspect ratio matches paper letter dimensions
+// 1650px / 1275px = 11" / 8.5" = 1.29
+export const MAP_CONTAINER_WIDTH = 1650;
+export const MAP_CONTAINER_HEIGHT = 1275;
+
 const OFFSET_X = 50;
 const OFFSET_Y = 25;
 
-const WIDTH_X = 1650 / 6; // 6 across 1650px map canvas width
-const WIDTH_Y = 1275 / 5; // 5 across 1275px map canvas height
+const WIDTH_X = MAP_CONTAINER_WIDTH / 6;
+const WIDTH_Y = MAP_CONTAINER_HEIGHT / 5;
 
 export const RESERVOIR_POSITIONS = [
     // Top

--- a/dashboard-ui/src/services/report/report.service.ts
+++ b/dashboard-ui/src/services/report/report.service.ts
@@ -659,7 +659,10 @@ export class ReportService {
         context.drawImage(mapCanvas, 0, 0);
         context.restore();
 
-        const legendPosition = { x: 1297, y: 519 };
+        const legendPosition = {
+            x: width - legendWidth - 20,
+            y: height - legendHeight - 20,
+        };
 
         if (reportLegend) {
             context.drawImage(


### PR DESCRIPTION
**Description**

This branch updates the report dimensions from `1600px`×`900px` to `1650px`×`1275px` so that the resultant aspect ratio (1.29) matches an `11"`×`8.5"` piece of letter paper.

Acceptance Criteria
* Report files have `1650px`×`1275px` dimensions
* Reservoir circle points render in the correct positions on the map
* Reservoir teacup images with descriptions distribute evenly around the edge of the report
* Legend is pinned to the lower-right corner of the report, regardless of its size

Layer | Screenshot
--- | ---
Drought | <img width="1650" height="1275" alt="drought" src="https://github.com/user-attachments/assets/a1d13468-9332-4207-9db1-e97922560f92" />
Drought (zoomed in) | <img width="1650" height="1275" alt="drought-zoomed" src="https://github.com/user-attachments/assets/818f3b05-c127-4352-81c5-a97be2fe7602" />
Precipitation | <img width="1650" height="1275" alt="precipitation" src="https://github.com/user-attachments/assets/2995b61c-c93e-48b2-bb36-8f1eb4b73104" />
Temperature | <img width="1650" height="1275" alt="temperature" src="https://github.com/user-attachments/assets/b1a79df9-8d9c-42c3-a864-167455c89d83" />
None | <img width="1650" height="1275" alt="none" src="https://github.com/user-attachments/assets/cac72565-8215-43a4-b4aa-5d2fa3afe3a4" />