### PR TITLE
Fix: prevent floating labels for default geo selection

### DIFF
--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -329,6 +329,9 @@ export const getLayerConfig = (
                 id: SubLayerId.RegionsFill,
                 type: LayerType.Fill,
                 source: SourceId.Regions,
+                layout: {
+                    visibility: 'none',
+                },
                 paint: {
                     'fill-color': getLayerColor(LayerId.Regions),
                     'fill-opacity': 0,


### PR DESCRIPTION
### **Quick Fix**
Addresses issues with labels showing on the map despite the default bounding geography being "None".


Current Behavior:
Labels for regions show when hovering over the map on initial load.

Expected Behavior:
Labels for regions only show on hover after selecting the appropriate geography bound.