### PR TITLE
Feature: add support for new managing regions layer

### DIFF
--- a/dashboard-ui/src/data/managingRegionCenters.ts
+++ b/dashboard-ui/src/data/managingRegionCenters.ts
@@ -12,57 +12,57 @@ export const managingRegionCenters: FeatureCollection<Point> = {
         {
             type: 'Feature',
             properties: {
-                [ManagingRegionField.ObjectId]: 1,
+                [ManagingRegionField.RegionAbbreviation]: 'UCB',
                 [ManagingRegionField.Name]: 'Upper Colorado Basin',
             },
             geometry: {
                 type: 'Point',
-                coordinates: [-101.0817, 46.9738],
+                coordinates: [-110.23976158144376, 39.29006838088944],
             },
         },
         {
             type: 'Feature',
             properties: {
-                [ManagingRegionField.ObjectId]: 2,
-                [ManagingRegionField.Name]:
-                    'Arkansas - Rio Grande - Texas Gulf',
-            },
-            geometry: {
-                type: 'Point',
-                coordinates: [-98.8068, 32.4998],
-            },
-        },
-        {
-            type: 'Feature',
-            properties: {
-                [ManagingRegionField.ObjectId]: 3,
-                [ManagingRegionField.Name]: 'Upper Colorado Basin',
-            },
-            geometry: {
-                type: 'Point',
-                coordinates: [-108.1286, 39.6615],
-            },
-        },
-        {
-            type: 'Feature',
-            properties: {
-                [ManagingRegionField.ObjectId]: 4,
-                [ManagingRegionField.Name]: 'Lower Colorado Basin',
-            },
-            geometry: {
-                type: 'Point',
-                coordinates: [-113.5361, 34.6394],
-            },
-        },
-        {
-            type: 'Feature',
-            properties: {
-                [ManagingRegionField.ObjectId]: 5,
+                [ManagingRegionField.RegionAbbreviation]: 'CPN',
                 [ManagingRegionField.Name]: 'Columbia - Pacific Northwest',
             },
             geometry: {
                 type: 'Point',
-                coordinates: [-118.702, 45.8915],
+                coordinates: [-118.57462350662891, 45.34871252235524],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                [ManagingRegionField.RegionAbbreviation]: 'CGB',
+                [ManagingRegionField.Name]: 'California-Great Basin',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-120.2021582733806, 40.33536183639052],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                [ManagingRegionField.RegionAbbreviation]: 'MB/ART',
+                [ManagingRegionField.Name]:
+                    'Missouri Basin and Arkansas-Rio Grande-Texas Gulf',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-103.54762219249345, 45.32613349005564],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                [ManagingRegionField.RegionAbbreviation]: 'LCB',
+                [ManagingRegionField.Name]: 'Lower Colorado Basin',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-113.20152774329691, 34.39957581265004],
             },
         },
     ],

--- a/dashboard-ui/src/data/managingRegionCenters.ts
+++ b/dashboard-ui/src/data/managingRegionCenters.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2025 Lincoln Institute of Land Policy
+ * SPDX-License-Identifier: MIT
+ */
+
+import { ManagingRegionField } from '@/features/Map/types/managingRegion';
+import { FeatureCollection, Point } from 'geojson';
+
+export const managingRegionCenters: FeatureCollection<Point> = {
+    type: 'FeatureCollection',
+    features: [
+        {
+            type: 'Feature',
+            properties: {
+                [ManagingRegionField.ObjectId]: 1,
+                [ManagingRegionField.Name]: 'Upper Colorado Basin',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-101.0817, 46.9738],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                [ManagingRegionField.ObjectId]: 2,
+                [ManagingRegionField.Name]:
+                    'Arkansas - Rio Grande - Texas Gulf',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-98.8068, 32.4998],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                [ManagingRegionField.ObjectId]: 3,
+                [ManagingRegionField.Name]: 'Upper Colorado Basin',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-108.1286, 39.6615],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                [ManagingRegionField.ObjectId]: 4,
+                [ManagingRegionField.Name]: 'Lower Colorado Basin',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-113.5361, 34.6394],
+            },
+        },
+        {
+            type: 'Feature',
+            properties: {
+                [ManagingRegionField.ObjectId]: 5,
+                [ManagingRegionField.Name]: 'Columbia - Pacific Northwest',
+            },
+            geometry: {
+                type: 'Point',
+                coordinates: [-118.702, 45.8915],
+            },
+        },
+    ],
+};

--- a/dashboard-ui/src/data/stateCenters.ts
+++ b/dashboard-ui/src/data/stateCenters.ts
@@ -12,7 +12,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Washington',
-                stusps: 'WA',
+                uri: 'https://geoconnex.us/ref/states/53',
             },
             geometry: {
                 type: 'Point',
@@ -24,7 +24,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Oregon',
-                stusps: 'OR',
+                uri: 'https://geoconnex.us/ref/states/41',
             },
             geometry: {
                 type: 'Point',
@@ -35,7 +35,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'California',
-                stusps: 'CA',
+                uri: 'https://geoconnex.us/ref/states/06',
             },
             geometry: {
                 type: 'Point',
@@ -46,7 +46,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Idaho',
-                stusps: 'ID',
+                uri: 'https://geoconnex.us/ref/states/16',
             },
             geometry: {
                 type: 'Point',
@@ -58,7 +58,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Nevada',
-                stusps: 'NV',
+                uri: 'https://geoconnex.us/ref/states/32',
             },
             geometry: {
                 type: 'Point',
@@ -70,7 +70,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Montana',
-                stusps: 'MT',
+                uri: 'https://geoconnex.us/ref/states/30',
             },
             geometry: {
                 type: 'Point',
@@ -81,7 +81,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Wyoming',
-                stusps: 'WY',
+                uri: 'https://geoconnex.us/ref/states/56',
             },
             geometry: {
                 type: 'Point',
@@ -93,7 +93,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Utah',
-                stusps: 'UT',
+                uri: 'https://geoconnex.us/ref/states/49',
             },
             geometry: {
                 type: 'Point',
@@ -104,7 +104,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Arizona',
-                stusps: 'AZ',
+                uri: 'https://geoconnex.us/ref/states/04',
             },
             geometry: {
                 type: 'Point',
@@ -115,7 +115,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Colorado',
-                stusps: 'CO',
+                uri: 'https://geoconnex.us/ref/states/08',
             },
             geometry: {
                 type: 'Point',
@@ -126,7 +126,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'New Mexico',
-                stusps: 'NM',
+                uri: 'https://geoconnex.us/ref/states/35',
             },
             geometry: {
                 type: 'Point',
@@ -137,7 +137,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'North Dakota',
-                stusps: 'ND',
+                uri: 'https://geoconnex.us/ref/states/38',
             },
             geometry: {
                 type: 'Point',
@@ -149,7 +149,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'South Dakota',
-                stusps: 'SD',
+                uri: 'https://geoconnex.us/ref/states/46',
             },
             geometry: {
                 type: 'Point',
@@ -160,7 +160,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Nebraska',
-                stusps: 'NE',
+                uri: 'https://geoconnex.us/ref/states/31',
             },
             geometry: {
                 type: 'Point',
@@ -171,7 +171,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Oklahoma',
-                stusps: 'OK',
+                uri: 'https://geoconnex.us/ref/states/40',
             },
             geometry: {
                 type: 'Point',
@@ -182,7 +182,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Kansas',
-                stusps: 'KS',
+                uri: 'https://geoconnex.us/ref/states/20',
             },
             geometry: {
                 type: 'Point',
@@ -193,7 +193,7 @@ export const stateCenters: FeatureCollection<Point> = {
             type: 'Feature',
             properties: {
                 name: 'Texas',
-                stusps: 'TX',
+                uri: 'https://geoconnex.us/ref/states/48',
             },
             geometry: {
                 type: 'Point',

--- a/dashboard-ui/src/features/Help/consts.tsx
+++ b/dashboard-ui/src/features/Help/consts.tsx
@@ -15,6 +15,8 @@ import {
 import GitHub from '@/icons/logos/Github';
 import { LayerId } from '@/features/Map/consts';
 import { getLayerName } from '@/features/Map/config';
+import { getBoundingGeographyLabel } from '@/utils/getBoundingGeographyLabel';
+import { BoundingGeographyLevel } from '@/stores/main/types';
 
 export type GlossaryBase = {
     id: string;
@@ -188,19 +190,25 @@ export const sections: GlossarySection[] = [
                 entries: [
                     {
                         id: LayerId.RegionsReference,
-                        label: 'DOI Region Boundaries',
+                        label: `${getBoundingGeographyLabel(BoundingGeographyLevel.Region)} Boundaries`,
                         content:
                             'The boundaries of Department of the Interior (DOI) Unified Regions. The dashboard only displays the boundaries of the DOI regions in the western US (Columbia-Pacific Northwest, California-Great Basin, Missouri Basin, Upper Colorado Basin, Lower Colorado Basin, and Arkansas-Rio Grande-Texas Gulf).',
                     },
                     {
+                        id: LayerId.ManagingRegionsReference,
+                        label: `${getBoundingGeographyLabel(BoundingGeographyLevel.ManagingRegion)} Boundaries`,
+                        content:
+                            'The boundaries of the Department of the Interior Regions that are responsible for managing Bureau of Reclamation assets.',
+                    },
+                    {
                         id: LayerId.BasinsReference,
-                        label: 'Basin (HUC2) Boundaries',
+                        label: `${getBoundingGeographyLabel(BoundingGeographyLevel.Basin)} Boundaries`,
                         content:
                             'The boundaries of 2-digit Hydrologic Units. Although the Watershed Boundary Dataset refers to these as “Regions”, they are labeled as “Basin (HUC2) Boundaries” in the Dashboard to avoid confusion with the DOI Region Boundaries.',
                     },
                     {
                         id: LayerId.StatesReference,
-                        label: 'State Boundaries',
+                        label: `${getBoundingGeographyLabel(BoundingGeographyLevel.State)} Boundaries`,
                         content:
                             'The boundaries of U.S. states. Only the 17 western states are displayed.',
                     },

--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -52,6 +52,8 @@ import { regionCenters } from '@/data/regionCenters';
 import { RegionField } from '@/features/Map/types/region';
 import useSessionStore from '@/stores/session';
 import useMainStore from '@/stores/main';
+import { ManagingRegionField } from './types/managingRegion';
+import { managingRegionCenters } from '@/data/managingRegionCenters';
 
 /**********************************************************************
  * Define the various datasources this map will use
@@ -77,6 +79,23 @@ export const sourceConfigs: SourceConfig[] = [
         definition: {
             type: 'geojson',
             data: regionCenters,
+            cluster: false,
+        },
+    },
+    {
+        id: SourceId.ManagingRegions,
+        type: Sources.GeoJSON,
+        definition: {
+            type: 'geojson',
+            data: 'https://cache.wwdh.internetofwater.app/collections/doi-reclamation-managing-regions/items?f=json',
+        },
+    },
+    {
+        id: SourceId.ManagingRegionCenters,
+        type: Sources.GeoJSON,
+        definition: {
+            type: 'geojson',
+            data: managingRegionCenters,
             cluster: false,
         },
     },
@@ -367,6 +386,72 @@ export const getLayerConfig = (
                 paint: {
                     'line-opacity': 1,
                     'line-color': getLayerColor(LayerId.RegionsReference),
+                    'line-width': 3,
+                },
+            };
+        case LayerId.ManagingRegions:
+            return null;
+        case SubLayerId.ManagingRegionsBoundary:
+            return {
+                id: SubLayerId.ManagingRegionsBoundary,
+                type: LayerType.Line,
+                source: SourceId.ManagingRegions,
+                layout: {
+                    visibility: 'none',
+                    'line-cap': 'round',
+                    'line-join': 'round',
+                },
+                paint: {
+                    'line-opacity': 1,
+                    'line-color': getLayerColor(LayerId.ManagingRegions),
+                    'line-width': 3,
+                },
+            };
+        case SubLayerId.ManagingRegionsFill:
+            return {
+                id: SubLayerId.ManagingRegionsFill,
+                type: LayerType.Fill,
+                source: SourceId.ManagingRegions,
+                paint: {
+                    'fill-color': getLayerColor(LayerId.ManagingRegions),
+                    'fill-opacity': 0,
+                },
+            };
+        case SubLayerId.ManagingRegionLabels:
+            return {
+                id: SubLayerId.ManagingRegionLabels,
+                type: LayerType.Symbol,
+                source: SourceId.ManagingRegionCenters,
+                layout: {
+                    'text-field': ['get', ManagingRegionField.Name], // TODO
+                    'text-font': ['Arial Unicode MS Bold'],
+                    'text-variable-anchor': ['top', 'bottom', 'left', 'right'],
+                    'text-size': 22,
+                    'text-allow-overlap': true,
+                    'text-ignore-placement': true,
+                },
+                paint: {
+                    'text-color': '#000',
+                    'text-opacity': 0,
+                    'text-halo-color': '#fff',
+                    'text-halo-width': 2,
+                },
+            };
+        case LayerId.ManagingRegionsReference:
+            return {
+                id: LayerId.ManagingRegionsReference,
+                type: LayerType.Line,
+                source: SourceId.ManagingRegions,
+                layout: {
+                    visibility: 'none',
+                    'line-cap': 'round',
+                    'line-join': 'round',
+                },
+                paint: {
+                    'line-opacity': 1,
+                    'line-color': getLayerColor(
+                        LayerId.ManagingRegionsReference
+                    ),
                     'line-width': 3,
                 },
             };
@@ -797,6 +882,41 @@ export const getLayerHoverFunction = (
                         }
                     }
                 };
+            case SubLayerId.ManagingRegionsFill:
+                return (e) => {
+                    const showAllLabels = useMainStore.getState().showAllLabels;
+
+                    if (showAllLabels) {
+                        return;
+                    }
+
+                    const zoom = map.getZoom();
+                    if (zoom < 12) {
+                        const feature = e.features?.[0] as
+                            | Feature<Polygon>
+                            | undefined;
+                        if (feature && feature.properties) {
+                            map.getCanvas().style.cursor = 'pointer';
+                            const id = feature.properties[
+                                ManagingRegionField.ObjectId
+                            ] as string;
+                            map.setPaintProperty(
+                                SubLayerId.ManagingRegionLabels,
+                                'text-opacity',
+                                [
+                                    'case',
+                                    [
+                                        '==',
+                                        ['get', ManagingRegionField.ObjectId],
+                                        id,
+                                    ],
+                                    1,
+                                    0,
+                                ]
+                            );
+                        }
+                    }
+                };
             case SubLayerId.BasinsFill:
                 return (e) => {
                     const showAllLabels = useMainStore.getState().showAllLabels;
@@ -1005,6 +1125,22 @@ export const getLayerCustomHoverExitFunction = (
                         0
                     );
                 };
+            case SubLayerId.ManagingRegionsFill:
+                return () => {
+                    map.getCanvas().style.cursor = '';
+
+                    const showAllLabels = useMainStore.getState().showAllLabels;
+
+                    if (showAllLabels) {
+                        return;
+                    }
+
+                    map.setPaintProperty(
+                        SubLayerId.ManagingRegionLabels,
+                        'text-opacity',
+                        0
+                    );
+                };
             case SubLayerId.BasinsFill:
                 return () => {
                     map.getCanvas().style.cursor = '';
@@ -1125,6 +1261,41 @@ export const getLayerMouseMoveFunction = (
                                 [
                                     'case',
                                     ['==', ['get', RegionField.RegNum], id],
+                                    1,
+                                    0,
+                                ]
+                            );
+                        }
+                    }
+                };
+            case SubLayerId.ManagingRegionsFill:
+                return (e) => {
+                    const showAllLabels = useMainStore.getState().showAllLabels;
+
+                    if (showAllLabels) {
+                        return;
+                    }
+
+                    const zoom = map.getZoom();
+                    if (zoom < 12) {
+                        const feature = e.features?.[0] as
+                            | Feature<Polygon>
+                            | undefined;
+                        if (feature && feature.properties) {
+                            map.getCanvas().style.cursor = 'pointer';
+                            const id = feature.properties[
+                                ManagingRegionField.ObjectId
+                            ] as string;
+                            map.setPaintProperty(
+                                SubLayerId.ManagingRegionLabels,
+                                'text-opacity',
+                                [
+                                    'case',
+                                    [
+                                        '==',
+                                        ['get', ManagingRegionField.ObjectId],
+                                        id,
+                                    ],
                                     1,
                                     0,
                                 ]
@@ -1586,6 +1757,35 @@ export const layerDefinitions: MainLayerDefinition[] = [
         ],
     },
     {
+        id: LayerId.ManagingRegions,
+        config: getLayerConfig(LayerId.ManagingRegions),
+        controllable: false,
+        legend: false,
+        subLayers: [
+            {
+                id: SubLayerId.ManagingRegionsBoundary,
+                config: getLayerConfig(SubLayerId.ManagingRegionsBoundary),
+                controllable: false,
+                legend: false,
+            },
+            {
+                id: SubLayerId.ManagingRegionsFill,
+                config: getLayerConfig(SubLayerId.ManagingRegionsFill),
+                controllable: false,
+                legend: false,
+                hoverFunction: getLayerHoverFunction(
+                    SubLayerId.ManagingRegionsFill
+                ),
+                mouseMoveFunction: getLayerMouseMoveFunction(
+                    SubLayerId.ManagingRegionsFill
+                ),
+                customHoverExitFunction: getLayerCustomHoverExitFunction(
+                    SubLayerId.ManagingRegionsFill
+                ),
+            },
+        ],
+    },
+    {
         id: LayerId.Basins,
         config: getLayerConfig(LayerId.Basins),
         controllable: false,
@@ -1677,6 +1877,12 @@ export const layerDefinitions: MainLayerDefinition[] = [
     {
         id: SubLayerId.RegionLabels,
         config: getLayerConfig(SubLayerId.RegionLabels),
+        controllable: false,
+        legend: false,
+    },
+    {
+        id: SubLayerId.ManagingRegionLabels,
+        config: getLayerConfig(SubLayerId.ManagingRegionLabels),
         controllable: false,
         legend: false,
     },

--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -301,6 +301,8 @@ export const getLayerColor = (
             return '#000';
         case LayerId.RegionsReference:
             return '#ef5e25';
+        case LayerId.ManagingRegionsReference:
+            return '#A10039';
         case LayerId.BasinsReference:
             return '#54278f';
         case LayerId.StatesReference:
@@ -1708,6 +1710,12 @@ export const layerDefinitions: MainLayerDefinition[] = [
     {
         id: LayerId.RegionsReference,
         config: getLayerConfig(LayerId.RegionsReference),
+        controllable: false,
+        legend: false,
+    },
+    {
+        id: LayerId.ManagingRegionsReference,
+        config: getLayerConfig(LayerId.ManagingRegionsReference),
         controllable: false,
         legend: false,
     },

--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -1537,11 +1537,6 @@ export const getLayerClickFunction = (
                         }
                     }
                 };
-            case SubLayerId.ManagingRegionsFill:
-                return (e) => {
-                    const { features } = e;
-                    console.log('features', e, e.point, features);
-                };
             case LayerId.NOAARiverForecast:
                 return (e) => {
                     hoverPopup.remove();
@@ -1799,9 +1794,6 @@ export const layerDefinitions: MainLayerDefinition[] = [
                 config: getLayerConfig(SubLayerId.ManagingRegionsFill),
                 controllable: false,
                 legend: false,
-                clickFunction: getLayerClickFunction(
-                    SubLayerId.ManagingRegionsFill
-                ),
                 hoverFunction: getLayerHoverFunction(
                     SubLayerId.ManagingRegionsFill
                 ),

--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -965,6 +965,8 @@ export const getLayerHoverFunction = (
                         return;
                     }
 
+                    console.log('e.features', e.features);
+
                     const zoom = map.getZoom();
                     if (zoom < 12) {
                         const feature = e.features?.[0] as

--- a/dashboard-ui/src/features/Map/config.tsx
+++ b/dashboard-ui/src/features/Map/config.tsx
@@ -293,6 +293,8 @@ export const getLayerColor = (
             return '#000';
         case LayerId.Basins:
             return '#000';
+        case LayerId.ManagingRegions:
+            return '#000';
         case LayerId.RiseEDRReservoirs:
             return '#00F';
         case LayerId.States:
@@ -348,6 +350,9 @@ export const getLayerConfig = (
                 id: SubLayerId.RegionsFill,
                 type: LayerType.Fill,
                 source: SourceId.Regions,
+                layout: {
+                    visibility: 'none',
+                },
                 paint: {
                     'fill-color': getLayerColor(LayerId.Regions),
                     'fill-opacity': 0,
@@ -412,6 +417,9 @@ export const getLayerConfig = (
                 id: SubLayerId.ManagingRegionsFill,
                 type: LayerType.Fill,
                 source: SourceId.ManagingRegions,
+                layout: {
+                    visibility: 'none',
+                },
                 paint: {
                     'fill-color': getLayerColor(LayerId.ManagingRegions),
                     'fill-opacity': 0,
@@ -898,7 +906,7 @@ export const getLayerHoverFunction = (
                         if (feature && feature.properties) {
                             map.getCanvas().style.cursor = 'pointer';
                             const id = feature.properties[
-                                ManagingRegionField.ObjectId
+                                ManagingRegionField.RegionAbbreviation
                             ] as string;
                             map.setPaintProperty(
                                 SubLayerId.ManagingRegionLabels,
@@ -907,7 +915,10 @@ export const getLayerHoverFunction = (
                                     'case',
                                     [
                                         '==',
-                                        ['get', ManagingRegionField.ObjectId],
+                                        [
+                                            'get',
+                                            ManagingRegionField.RegionAbbreviation,
+                                        ],
                                         id,
                                     ],
                                     1,
@@ -1284,7 +1295,7 @@ export const getLayerMouseMoveFunction = (
                         if (feature && feature.properties) {
                             map.getCanvas().style.cursor = 'pointer';
                             const id = feature.properties[
-                                ManagingRegionField.ObjectId
+                                ManagingRegionField.RegionAbbreviation
                             ] as string;
                             map.setPaintProperty(
                                 SubLayerId.ManagingRegionLabels,
@@ -1293,7 +1304,10 @@ export const getLayerMouseMoveFunction = (
                                     'case',
                                     [
                                         '==',
-                                        ['get', ManagingRegionField.ObjectId],
+                                        [
+                                            'get',
+                                            ManagingRegionField.RegionAbbreviation,
+                                        ],
                                         id,
                                     ],
                                     1,
@@ -1521,7 +1535,11 @@ export const getLayerClickFunction = (
                         }
                     }
                 };
-
+            case SubLayerId.ManagingRegionsFill:
+                return (e) => {
+                    const { features } = e;
+                    console.log('features', e, e.point, features);
+                };
             case LayerId.NOAARiverForecast:
                 return (e) => {
                     hoverPopup.remove();
@@ -1773,6 +1791,9 @@ export const layerDefinitions: MainLayerDefinition[] = [
                 config: getLayerConfig(SubLayerId.ManagingRegionsFill),
                 controllable: false,
                 legend: false,
+                clickFunction: getLayerClickFunction(
+                    SubLayerId.ManagingRegionsFill
+                ),
                 hoverFunction: getLayerHoverFunction(
                     SubLayerId.ManagingRegionsFill
                 ),

--- a/dashboard-ui/src/features/Map/consts.ts
+++ b/dashboard-ui/src/features/Map/consts.ts
@@ -271,6 +271,8 @@ export const ReservoirConfigs: Record<
         longLabelProperty: TeacupReservoirField.PopupLabel,
         chartLabel: TeacupReservoirField.Storage,
         regionConnectorProperty: TeacupReservoirField.RegionName,
+        managingRegionConnectorProperty:
+            TeacupReservoirField.ManagingRegionAbbreviation,
         basinConnectorProperty: TeacupReservoirField.Huc02,
         stateConnectorProperty: TeacupReservoirField.State,
         iconLayer: LayerId.TeacupEDRReservoirs,

--- a/dashboard-ui/src/features/Map/consts.ts
+++ b/dashboard-ui/src/features/Map/consts.ts
@@ -25,6 +25,8 @@ export const US_BBOX: BBox = [-171.791111, 18.91619, -66.96466, 71.357764];
 export enum SourceId {
     Regions = 'regions',
     RegionCenters = 'regions-center',
+    ManagingRegions = 'doi-reclamation-managing-regions',
+    ManagingRegionCenters = 'doi-reclamation-managing-regions-center',
     Basins = 'hu02',
     BasinCenters = 'hu02-center',
     States = 'states',
@@ -46,6 +48,8 @@ export enum SourceId {
 export enum LayerId {
     Regions = 'dash-regions-main',
     RegionsReference = 'dash-regions-reference',
+    ManagingRegions = 'dash-managing-regions-main',
+    ManagingRegionsReference = 'dash-managing-regions-reference',
     Basins = 'dash-basins-main',
     BasinsReference = 'dash-basins-reference',
     States = 'dash-states-main',
@@ -68,6 +72,10 @@ export enum SubLayerId {
     RegionsBoundary = 'dash-regions-boundary',
     RegionsFill = 'dash-regions-fill',
     RegionLabels = 'dash-regions-labels',
+
+    ManagingRegionsBoundary = 'dash-managing-regions-boundary',
+    ManagingRegionsFill = 'dash-managing-regions-fill',
+    ManagingRegionLabels = 'dash-managing-regions-labels',
 
     BasinsBoundary = 'dash-basins-boundary',
     BasinsFill = 'dash-basins-fill',

--- a/dashboard-ui/src/features/Map/index.tsx
+++ b/dashboard-ui/src/features/Map/index.tsx
@@ -57,6 +57,7 @@ import { customLoader } from '@/services/sprite/customLoader';
 import { ReservoirConfigId } from '@/features/Map/types';
 import { useMediaQuery } from '@mantine/hooks';
 import { MOBILE_MEDIA_QUERY } from '@/features/Main/consts';
+import { ManagingRegionField } from './types/managingRegion';
 
 type Props = {
     accessToken: string;
@@ -80,6 +81,8 @@ const MainMap: React.FC<Props> = (props) => {
     );
     const region = useMainStore((state) => state.region);
     const setRegion = useMainStore((state) => state.setRegion);
+    const managingRegion = useMainStore((state) => state.managingRegion);
+    const setManagingRegion = useMainStore((state) => state.setManagingRegion);
     const basin = useMainStore((state) => state.basin);
     const setBasin = useMainStore((state) => state.setBasin);
     const state = useMainStore((state) => state.state);
@@ -389,6 +392,30 @@ const MainMap: React.FC<Props> = (props) => {
         if (!map) {
             return;
         }
+        if (managingRegion.length === 0) {
+            // Unset Filter
+            map.setFilter(SubLayerId.ManagingRegionsFill, null);
+            map.setFilter(SubLayerId.ManagingRegionsBoundary, null);
+        } else {
+            map.setFilter(SubLayerId.ManagingRegionsFill, [
+                'in',
+                ['get', ManagingRegionField.RegionAbbreviation],
+                ['literal', managingRegion],
+            ]);
+            map.setFilter(SubLayerId.ManagingRegionsBoundary, [
+                'in',
+                ['get', ManagingRegionField.RegionAbbreviation],
+                ['literal', managingRegion],
+            ]);
+        }
+
+        updateReservoirFilters(map);
+    }, [managingRegion]);
+
+    useEffect(() => {
+        if (!map) {
+            return;
+        }
         if (basin.length === 0) {
             // Unset Filter
             map.setFilter(SubLayerId.BasinsFill, [
@@ -456,6 +483,7 @@ const MainMap: React.FC<Props> = (props) => {
                 });
                 if (!features.length) {
                     setRegion([]);
+                    setManagingRegion([]);
                     setBasin([]);
                     setState([]);
                     setReservoir(ReservoirDefault);
@@ -602,6 +630,13 @@ const MainMap: React.FC<Props> = (props) => {
         if (map.getLayer(SubLayerId.RegionLabels)) {
             map.setPaintProperty(SubLayerId.RegionLabels, 'text-opacity', 0);
         }
+        if (map.getLayer(SubLayerId.ManagingRegionLabels)) {
+            map.setPaintProperty(
+                SubLayerId.ManagingRegionLabels,
+                'text-opacity',
+                0
+            );
+        }
         if (map.getLayer(SubLayerId.BasinLabels)) {
             map.setPaintProperty(SubLayerId.BasinLabels, 'text-opacity', 0);
         }
@@ -623,6 +658,31 @@ const MainMap: React.FC<Props> = (props) => {
                 } else {
                     map.setPaintProperty(
                         SubLayerId.RegionLabels,
+                        'text-opacity',
+                        1
+                    );
+                }
+            }
+            if (
+                boundingGeographyLevel ===
+                    BoundingGeographyLevel.ManagingRegion &&
+                map.getLayer(SubLayerId.ManagingRegionLabels)
+            ) {
+                if (managingRegion.length > 0) {
+                    map.setPaintProperty(
+                        SubLayerId.ManagingRegionLabels,
+                        'text-opacity',
+                        [
+                            'match',
+                            ['get', ManagingRegionField.RegionAbbreviation],
+                            managingRegion,
+                            1,
+                            0,
+                        ]
+                    );
+                } else {
+                    map.setPaintProperty(
+                        SubLayerId.ManagingRegionLabels,
                         'text-opacity',
                         1
                     );
@@ -665,7 +725,14 @@ const MainMap: React.FC<Props> = (props) => {
                 }
             }
         }
-    }, [boundingGeographyLevel, showAllLabels, region, basin, state]);
+    }, [
+        boundingGeographyLevel,
+        showAllLabels,
+        region,
+        managingRegion,
+        basin,
+        state,
+    ]);
 
     useEffect(() => {
         if (!map) {

--- a/dashboard-ui/src/features/Map/index.tsx
+++ b/dashboard-ui/src/features/Map/index.tsx
@@ -649,80 +649,62 @@ const MainMap: React.FC<Props> = (props) => {
                 boundingGeographyLevel === BoundingGeographyLevel.Region &&
                 map.getLayer(SubLayerId.RegionLabels)
             ) {
-                if (region.length > 0) {
-                    map.setPaintProperty(
-                        SubLayerId.RegionLabels,
-                        'text-opacity',
-                        ['match', ['get', RegionField.Name], region, 1, 0]
-                    );
-                } else {
-                    map.setPaintProperty(
-                        SubLayerId.RegionLabels,
-                        'text-opacity',
-                        1
-                    );
-                }
+                map.setPaintProperty(
+                    SubLayerId.RegionLabels,
+                    'text-opacity',
+                    region.length > 0
+                        ? ['match', ['get', RegionField.Name], region, 1, 0]
+                        : 1
+                );
             }
             if (
                 boundingGeographyLevel ===
                     BoundingGeographyLevel.ManagingRegion &&
                 map.getLayer(SubLayerId.ManagingRegionLabels)
             ) {
-                if (managingRegion.length > 0) {
-                    map.setPaintProperty(
-                        SubLayerId.ManagingRegionLabels,
-                        'text-opacity',
-                        [
-                            'match',
-                            ['get', ManagingRegionField.RegionAbbreviation],
-                            managingRegion,
-                            1,
-                            0,
-                        ]
-                    );
-                } else {
-                    map.setPaintProperty(
-                        SubLayerId.ManagingRegionLabels,
-                        'text-opacity',
-                        1
-                    );
-                }
+                map.setPaintProperty(
+                    SubLayerId.ManagingRegionLabels,
+                    'text-opacity',
+                    managingRegion.length > 0
+                        ? [
+                              'match',
+                              ['get', ManagingRegionField.RegionAbbreviation],
+                              managingRegion,
+                              1,
+                              0,
+                          ]
+                        : 1
+                );
             }
             if (
                 boundingGeographyLevel === BoundingGeographyLevel.Basin &&
                 map.getLayer(SubLayerId.BasinLabels)
             ) {
-                if (basin.length > 0) {
-                    map.setPaintProperty(
-                        SubLayerId.BasinLabels,
-                        'text-opacity',
-                        ['match', ['get', Huc02BasinField.Id], basin, 1, 0]
-                    );
-                } else {
-                    map.setPaintProperty(
-                        SubLayerId.BasinLabels,
-                        'text-opacity',
-                        1
-                    );
-                }
+                map.setPaintProperty(
+                    SubLayerId.BasinLabels,
+                    'text-opacity',
+                    basin.length > 0
+                        ? [
+                              'match',
+                              ['to-string', ['get', Huc02BasinField.Id]],
+                              basin,
+                              1,
+                              0,
+                          ]
+                        : 1
+                );
             }
             if (
                 boundingGeographyLevel === BoundingGeographyLevel.State &&
                 map.getLayer(SubLayerId.StateLabels)
             ) {
-                if (state.length > 0) {
-                    map.setPaintProperty(
-                        SubLayerId.StateLabels,
-                        'text-opacity',
-                        ['match', ['get', StateField.Acronym], state, 1, 0]
-                    );
-                } else {
-                    map.setPaintProperty(
-                        SubLayerId.StateLabels,
-                        'text-opacity',
-                        1
-                    );
-                }
+                map.setPaintProperty(
+                    SubLayerId.StateLabels,
+                    'text-opacity',
+                    state.length > 0
+                        ? ['match', ['get', StateField.Uri], state, 1, 0]
+                        : 1
+                );
             }
         }
     }, [

--- a/dashboard-ui/src/features/Map/types.ts
+++ b/dashboard-ui/src/features/Map/types.ts
@@ -36,6 +36,7 @@ export type ReservoirConfigProperties = {
     longLabelProperty: string;
     chartLabel: string;
     regionConnectorProperty: string;
+    managingRegionConnectorProperty: string;
     basinConnectorProperty: string;
     stateConnectorProperty: string;
     iconLayer: LayerId | SubLayerId;

--- a/dashboard-ui/src/features/Map/types/managingRegion.ts
+++ b/dashboard-ui/src/features/Map/types/managingRegion.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2025 Lincoln Institute of Land Policy
+ * SPDX-License-Identifier: MIT
+ */
+export enum ManagingRegionField {
+    ObjectId = 'OBJECTID_1',
+    Name = 'REGION',
+    RegionAbbreviation = 'REGION_ABBREVIATION',
+    GlobalID = 'GlobalID',
+}
+
+export type ManagingRegionProperties = {
+    [ManagingRegionField.ObjectId]: number;
+    [ManagingRegionField.Name]: string;
+    [ManagingRegionField.RegionAbbreviation]: string;
+    [ManagingRegionField.GlobalID]: string;
+};

--- a/dashboard-ui/src/features/Map/types/managingRegion.ts
+++ b/dashboard-ui/src/features/Map/types/managingRegion.ts
@@ -4,8 +4,8 @@
  */
 export enum ManagingRegionField {
     ObjectId = 'OBJECTID_1',
-    Name = 'REGION',
-    RegionAbbreviation = 'REGION_ABBREVIATION',
+    Name = 'managingregion',
+    RegionAbbreviation = 'abbreviation',
     GlobalID = 'GlobalID',
 }
 

--- a/dashboard-ui/src/features/Map/types/reservoir/teacup.ts
+++ b/dashboard-ui/src/features/Map/types/reservoir/teacup.ts
@@ -15,6 +15,7 @@ export enum TeacupReservoirField {
     Huc12 = 'huc12',
     RegionName = 'reg_name',
     RegionId = 'reg_num',
+    ManagingRegionAbbreviation = 'mng_reg_abbr',
     State = 'state',
     Source = 'source_uri',
     UseTotalOrActiveStorage = 'storage_capacity_label',
@@ -42,6 +43,7 @@ export type TeacupReservoirProperties = {
     [TeacupReservoirField.Huc12]: number;
     [TeacupReservoirField.RegionName]: string;
     [TeacupReservoirField.RegionId]: number;
+    [TeacupReservoirField.ManagingRegionAbbreviation]: string;
     [TeacupReservoirField.State]: string;
     [TeacupReservoirField.Source]: string;
     [TeacupReservoirField.UseTotalOrActiveStorage]: string;

--- a/dashboard-ui/src/features/Map/utils.ts
+++ b/dashboard-ui/src/features/Map/utils.ts
@@ -871,6 +871,8 @@ const getProperty = (
     switch (boundingGeographyLevel) {
         case BoundingGeographyLevel.Region:
             return 'regionConnectorProperty';
+        case BoundingGeographyLevel.ManagingRegion:
+            return 'managingRegionConnectorProperty';
         case BoundingGeographyLevel.Basin:
             return 'basinConnectorProperty';
         default:
@@ -881,6 +883,7 @@ const getProperty = (
 
 const getFilterValue = (
     region: string[],
+    managingRegion: string[],
     basin: string[],
     state: string[],
     boundingGeographyLevel: BoundingGeographyLevel
@@ -890,6 +893,12 @@ const getFilterValue = (
         region.length > 0
     ) {
         return region;
+    }
+    if (
+        boundingGeographyLevel === BoundingGeographyLevel.ManagingRegion &&
+        managingRegion.length > 0
+    ) {
+        return managingRegion;
     }
     if (
         boundingGeographyLevel === BoundingGeographyLevel.Basin &&
@@ -958,6 +967,7 @@ export const updateReservoirFilters = (map: Map) => {
     const {
         boundingGeographyLevel,
         region = [],
+        managingRegion = [],
         basin = [],
         state = [],
         reservoir,
@@ -965,15 +975,17 @@ export const updateReservoirFilters = (map: Map) => {
     const { hideNoData } = useSessionStore.getState();
 
     const hasBoundingGeography =
-        (region?.length ?? 0) > 0 ||
-        (basin?.length ?? 0) > 0 ||
-        (state?.length ?? 0) > 0;
+        region.length > 0 ||
+        managingRegion.length > 0 ||
+        basin.length > 0 ||
+        state.length > 0;
 
     const property = getProperty(boundingGeographyLevel);
     const filterValue = getFilterValue(
-        region ?? [],
-        basin ?? [],
-        state ?? [],
+        region,
+        managingRegion,
+        basin,
+        state,
         boundingGeographyLevel
     );
 

--- a/dashboard-ui/src/features/MapTools/Legend/Content.tsx
+++ b/dashboard-ui/src/features/MapTools/Legend/Content.tsx
@@ -86,6 +86,16 @@ export const Content: React.FC<Props> = (props) => {
                     </Title>
                 </Group>
             )}
+            {toggleableLayers[LayerId.ManagingRegionsReference] && (
+                <Group gap="calc(var(--default-spacing) / 2)">
+                    <Box className={styles.iconBackground}>
+                        <Line color="#A10039" />
+                    </Box>
+                    <Title order={4} size="h6">
+                        Managing Region Boundaries
+                    </Title>
+                </Group>
+            )}
             {toggleableLayers[LayerId.BasinsReference] && (
                 <Group gap="calc(var(--default-spacing) / 2)">
                     <Box className={styles.iconBackground}>

--- a/dashboard-ui/src/features/MapTools/Legend/Content.tsx
+++ b/dashboard-ui/src/features/MapTools/Legend/Content.tsx
@@ -9,7 +9,15 @@ import { Gradient } from '@/features/MapTools/Legend/Gradient';
 import styles from '@/features/MapTools/Legend/Legend.module.css';
 import { getLayerName } from '@/features/Map/config';
 import { MainState } from '@/stores/main';
-import { Box, Divider, Group, Stack, Title, Tooltip } from '@mantine/core';
+import {
+    Box,
+    Divider,
+    Group,
+    Stack,
+    Title,
+    TitleProps,
+    Tooltip,
+} from '@mantine/core';
 import {
     getTooltipContent,
     isGradientEntry,
@@ -21,17 +29,29 @@ import { Teacups } from '@/features/MapTools/Legend/Teacups';
 import { LayerId } from '@/features/Map/consts';
 import { Items } from '@/features/MapTools/Legend/Items';
 import { Groups } from '@/features/MapTools/Legend/Groups';
+import { BoundingGeographyLevel } from '@/stores/main/types';
+import { getBoundingGeographyLabel } from '@/utils/getBoundingGeographyLabel';
 
 type Props = {
     entries: TEntry[];
     toggleableLayers: MainState['toggleableLayers'];
+    boundingGeographyLevel: BoundingGeographyLevel;
 };
 
 export const Content: React.FC<Props> = (props) => {
-    const { entries, toggleableLayers } = props;
+    const { entries, toggleableLayers, boundingGeographyLevel } = props;
+
+    const titleProps: TitleProps = {
+        order: 4,
+        size: 'h6',
+        maw: '85%',
+    };
 
     return (
-        <Stack className={styles.wrapper}>
+        <Stack
+            className={styles.wrapper}
+            gap="calc(var(--default-spacing) * 2)"
+        >
             <Teacups />
             <Divider />
             {entries
@@ -76,13 +96,27 @@ export const Content: React.FC<Props> = (props) => {
                         {isGroupsEntry(entry) && <Groups entry={entry} />}
                     </li>
                 ))}
+            {boundingGeographyLevel !== BoundingGeographyLevel.None && (
+                <Group gap="calc(var(--default-spacing) / 2)">
+                    <Box className={styles.iconBackground}>
+                        <Line color="#000" />
+                    </Box>
+                    <Title {...titleProps}>
+                        {getBoundingGeographyLabel(boundingGeographyLevel)}{' '}
+                        Filter Boundaries
+                    </Title>
+                </Group>
+            )}
             {toggleableLayers[LayerId.RegionsReference] && (
                 <Group gap="calc(var(--default-spacing) / 2)">
                     <Box className={styles.iconBackground}>
                         <Line color="#ef5e25" />
                     </Box>
-                    <Title order={4} size="h6">
-                        DOI Region Boundaries
+                    <Title {...titleProps}>
+                        {getBoundingGeographyLabel(
+                            BoundingGeographyLevel.Region
+                        )}{' '}
+                        Reference Boundaries
                     </Title>
                 </Group>
             )}
@@ -91,8 +125,11 @@ export const Content: React.FC<Props> = (props) => {
                     <Box className={styles.iconBackground}>
                         <Line color="#A10039" />
                     </Box>
-                    <Title order={4} size="h6">
-                        Managing Region Boundaries
+                    <Title {...titleProps}>
+                        {getBoundingGeographyLabel(
+                            BoundingGeographyLevel.ManagingRegion
+                        )}{' '}
+                        Reference Boundaries
                     </Title>
                 </Group>
             )}
@@ -101,8 +138,11 @@ export const Content: React.FC<Props> = (props) => {
                     <Box className={styles.iconBackground}>
                         <Line color="#54278f" />
                     </Box>
-                    <Title order={4} size="h6">
-                        Basin (HUC2) Boundaries
+                    <Title {...titleProps}>
+                        {getBoundingGeographyLabel(
+                            BoundingGeographyLevel.Basin
+                        )}{' '}
+                        Reference Boundaries
                     </Title>
                 </Group>
             )}
@@ -111,8 +151,11 @@ export const Content: React.FC<Props> = (props) => {
                     <Box className={styles.iconBackground}>
                         <Line color="#34a37e" />
                     </Box>
-                    <Title order={4} size="h6">
-                        State Boundaries
+                    <Title {...titleProps}>
+                        {getBoundingGeographyLabel(
+                            BoundingGeographyLevel.State
+                        )}{' '}
+                        Reference Boundaries
                     </Title>
                 </Group>
             )}

--- a/dashboard-ui/src/features/MapTools/Legend/Legend.module.css
+++ b/dashboard-ui/src/features/MapTools/Legend/Legend.module.css
@@ -120,4 +120,6 @@
 .wrapper {
     display: flex;
     max-width: 18.25rem;
+    max-height: calc(100vh - 5.6875rem);
+    overflow-y: auto;
 }

--- a/dashboard-ui/src/features/MapTools/Legend/Teacups.tsx
+++ b/dashboard-ui/src/features/MapTools/Legend/Teacups.tsx
@@ -17,7 +17,7 @@ export const Teacups: React.FC = () => {
                 <Image
                     src="/map-icons/teacup-65-50.png"
                     alt="Reservoir Teacup Icon"
-                    h={60}
+                    h={50}
                     w="auto"
                     fit="contain"
                 />

--- a/dashboard-ui/src/features/MapTools/Legend/index.tsx
+++ b/dashboard-ui/src/features/MapTools/Legend/index.tsx
@@ -27,6 +27,9 @@ import { MOBILE_MEDIA_QUERY } from '@/features/Main/consts';
 
 const Legend: React.FC = () => {
     const toggleableLayers = useMainStore((state) => state.toggleableLayers);
+    const boundingGeographyLevel = useMainStore(
+        (state) => state.boundingGeographyLevel
+    );
 
     const overlay = useSessionStore((state) => state.overlay);
     const setOverlay = useSessionStore((state) => state.setOverlay);
@@ -89,6 +92,7 @@ const Legend: React.FC = () => {
                     <Content
                         entries={entries}
                         toggleableLayers={toggleableLayers}
+                        boundingGeographyLevel={boundingGeographyLevel}
                     />
                 </PopoverDropdown>
             </Popover>
@@ -106,6 +110,7 @@ const Legend: React.FC = () => {
                     <Content
                         entries={entries}
                         toggleableLayers={toggleableLayers}
+                        boundingGeographyLevel={boundingGeographyLevel}
                     />
                 </Box>
                 <img

--- a/dashboard-ui/src/features/MapTools/Legend/utils.tsx
+++ b/dashboard-ui/src/features/MapTools/Legend/utils.tsx
@@ -36,7 +36,7 @@ export const getTooltipContent = (
         case String(LayerId.RegionsReference):
             return 'The boundaries of the Department of the Interior Unified Regions in the western U.S.';
         case String(LayerId.ManagingRegionsReference):
-            return 'The boundaries of the Department of the Interior Regions that are responsible for managing Bureau of Reclamation assets';
+            return 'The boundaries of the Department of the Interior Regions that are responsible for managing Bureau of Reclamation assets.';
         case String(LayerId.BasinsReference):
             return 'The boundaries of 2-digit Hydrologic Units.';
         case String(LayerId.StatesReference):

--- a/dashboard-ui/src/features/MapTools/Legend/utils.tsx
+++ b/dashboard-ui/src/features/MapTools/Legend/utils.tsx
@@ -35,6 +35,8 @@ export const getTooltipContent = (
             return '';
         case String(LayerId.RegionsReference):
             return 'The boundaries of the Department of the Interior Unified Regions in the western U.S.';
+        case String(LayerId.ManagingRegionsReference):
+            return 'The boundareis of the Department of Interior Regions that are responsible for managing Bureau of Reclamation assets';
         case String(LayerId.BasinsReference):
             return 'The boundaries of 2-digit Hydrologic Units.';
         case String(LayerId.StatesReference):

--- a/dashboard-ui/src/features/MapTools/Legend/utils.tsx
+++ b/dashboard-ui/src/features/MapTools/Legend/utils.tsx
@@ -36,7 +36,7 @@ export const getTooltipContent = (
         case String(LayerId.RegionsReference):
             return 'The boundaries of the Department of the Interior Unified Regions in the western U.S.';
         case String(LayerId.ManagingRegionsReference):
-            return 'The boundareis of the Department of Interior Regions that are responsible for managing Bureau of Reclamation assets';
+            return 'The boundaries of the Department of the Interior Regions that are responsible for managing Bureau of Reclamation assets';
         case String(LayerId.BasinsReference):
             return 'The boundaries of 2-digit Hydrologic Units.';
         case String(LayerId.StatesReference):

--- a/dashboard-ui/src/features/ReferenceData/Entry.tsx
+++ b/dashboard-ui/src/features/ReferenceData/Entry.tsx
@@ -13,7 +13,10 @@ import { MainState } from '@/stores/main';
 type Props = {
     layerId: keyof MainState['toggleableLayers'];
     label: string;
-    onClick: (visible: boolean) => void;
+    onClick: (
+        layerId: keyof MainState['toggleableLayers'],
+        visible: boolean
+    ) => void;
     toggleableLayers: MainState['toggleableLayers'];
     links?: boolean;
     disabled?: boolean;
@@ -60,7 +63,7 @@ export const Entry: React.FC<Props> = (props) => {
                 }
                 aria-label={label}
                 checked={toggleableLayers[layerId]}
-                onClick={() => onClick(!toggleableLayers[layerId])}
+                onClick={() => onClick(layerId, !toggleableLayers[layerId])}
                 disabled={disabled}
             />
             {links && (

--- a/dashboard-ui/src/features/ReferenceData/index.tsx
+++ b/dashboard-ui/src/features/ReferenceData/index.tsx
@@ -30,6 +30,8 @@ import { Entry } from '@/features/ReferenceData/Entry';
 import { getLayerName } from '@/features/Map/config';
 import { useLoading } from '@/hooks/useLoading';
 import Info from '@/icons/Info';
+import { getBoundingGeographyLabel } from '@/utils/getBoundingGeographyLabel';
+import { BoundingGeographyLevel } from '@/stores/main/types';
 
 const RasterBaseLayerIconObj = [
     {
@@ -257,28 +259,28 @@ const ReferenceData: React.FC = () => {
                     <Divider size="md" />
                     <Entry
                         layerId={LayerId.RegionsReference}
-                        label="Show DOI Region Boundaries"
+                        label={`Show ${getBoundingGeographyLabel(BoundingGeographyLevel.Region)} Boundaries`}
                         onClick={handleLayerVisibilityChange}
                         toggleableLayers={toggleableLayers}
                         links={false}
                     />
                     <Entry
                         layerId={LayerId.ManagingRegionsReference}
-                        label="Show Managing Region Boundaries"
+                        label={`Show ${getBoundingGeographyLabel(BoundingGeographyLevel.ManagingRegion)} Boundaries`}
                         onClick={handleLayerVisibilityChange}
                         toggleableLayers={toggleableLayers}
                         links={false}
                     />
                     <Entry
                         layerId={LayerId.BasinsReference}
-                        label="Show Basin (HUC2) Boundaries"
+                        label={`Show ${getBoundingGeographyLabel(BoundingGeographyLevel.Basin)} Boundaries`}
                         onClick={handleLayerVisibilityChange}
                         toggleableLayers={toggleableLayers}
                         links={false}
                     />
                     <Entry
                         layerId={LayerId.StatesReference}
-                        label="Show State Boundaries"
+                        label={`Show ${getBoundingGeographyLabel(BoundingGeographyLevel.State)} Boundaries`}
                         onClick={handleLayerVisibilityChange}
                         toggleableLayers={toggleableLayers}
                         links={false}

--- a/dashboard-ui/src/features/ReferenceData/index.tsx
+++ b/dashboard-ui/src/features/ReferenceData/index.tsx
@@ -19,7 +19,7 @@ import { BaseLayerOpacity, LayerId, MAP_ID } from '@/features/Map/consts';
 import { useMap } from '@/contexts/MapContexts';
 import { RasterBaseLayers } from '@/features/Map/types';
 import { useEffect, useRef, useState } from 'react';
-import useMainStore from '@/stores/main';
+import useMainStore, { MainState } from '@/stores/main';
 import {
     RasterVisibilityMap,
     updateBaseLayerOpacity,
@@ -101,44 +101,15 @@ const ReferenceData: React.FC = () => {
         setBaseLayerOpacity(baseLayerOpacity);
     };
 
-    const handleNOAARFCChange = (showNOAARFC: boolean) => {
+    const handleLayerVisibilityChange = (
+        layerId: keyof MainState['toggleableLayers'],
+        visible: boolean
+    ) => {
         if (!map) {
             return;
         }
 
-        setToggleableLayers(LayerId.NOAARiverForecast, showNOAARFC);
-    };
-
-    const handleSnotelChange = (showSnotel: boolean) => {
-        if (!map) {
-            return;
-        }
-
-        setToggleableLayers(LayerId.SnotelHucSixMeans, showSnotel);
-    };
-
-    const handleRegionsReferenceChange = (showRegionsReference: boolean) => {
-        if (!map) {
-            return;
-        }
-
-        setToggleableLayers(LayerId.RegionsReference, showRegionsReference);
-    };
-
-    const handleBasinsReferenceChange = (showBasinsReference: boolean) => {
-        if (!map) {
-            return;
-        }
-
-        setToggleableLayers(LayerId.BasinsReference, showBasinsReference);
-    };
-
-    const handleStatesReferenceChange = (showStatesReference: boolean) => {
-        if (!map) {
-            return;
-        }
-
-        setToggleableLayers(LayerId.StatesReference, showStatesReference);
+        setToggleableLayers(layerId, visible);
     };
 
     const getBaseLayerValue = (): RasterBaseLayers => {
@@ -183,7 +154,7 @@ const ReferenceData: React.FC = () => {
                     <Entry
                         layerId={LayerId.NOAARiverForecast}
                         label={`Show ${getLayerName(LayerId.NOAARiverForecast)}`}
-                        onClick={handleNOAARFCChange}
+                        onClick={handleLayerVisibilityChange}
                         toggleableLayers={toggleableLayers}
                         disabled={isReferenceDataDisabled}
                     />
@@ -230,7 +201,7 @@ const ReferenceData: React.FC = () => {
                     <Entry
                         layerId={LayerId.SnotelHucSixMeans}
                         label={`Show ${getLayerName(LayerId.SnotelHucSixMeans)}`}
-                        onClick={handleSnotelChange}
+                        onClick={handleLayerVisibilityChange}
                         toggleableLayers={toggleableLayers}
                         disabled={isReferenceDataDisabled}
                     />
@@ -287,21 +258,28 @@ const ReferenceData: React.FC = () => {
                     <Entry
                         layerId={LayerId.RegionsReference}
                         label="Show DOI Region Boundaries"
-                        onClick={handleRegionsReferenceChange}
+                        onClick={handleLayerVisibilityChange}
+                        toggleableLayers={toggleableLayers}
+                        links={false}
+                    />
+                    <Entry
+                        layerId={LayerId.ManagingRegionsReference}
+                        label="Show Managing Region Boundaries"
+                        onClick={handleLayerVisibilityChange}
                         toggleableLayers={toggleableLayers}
                         links={false}
                     />
                     <Entry
                         layerId={LayerId.BasinsReference}
                         label="Show Basin (HUC2) Boundaries"
-                        onClick={handleBasinsReferenceChange}
+                        onClick={handleLayerVisibilityChange}
                         toggleableLayers={toggleableLayers}
                         links={false}
                     />
                     <Entry
                         layerId={LayerId.StatesReference}
                         label="Show State Boundaries"
-                        onClick={handleStatesReferenceChange}
+                        onClick={handleLayerVisibilityChange}
                         toggleableLayers={toggleableLayers}
                         links={false}
                     />

--- a/dashboard-ui/src/features/Reservoirs/Filter/Selectors/Basin.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/Selectors/Basin.tsx
@@ -9,7 +9,7 @@ import { MultiSelect, Skeleton } from '@mantine/core';
 import useMainStore from '@/stores/main';
 import { useMap } from '@/contexts/MapContexts';
 import { MAP_ID, SourceId, ValidBasins } from '@/features/Map/consts';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import styles from '@/features/Reservoirs/Reservoirs.module.css';
 import geoconnexService from '@/services/init/geoconnex.init';
 import { formatOptions } from '@/features/Reservoirs/Filter/Selectors/utils';
@@ -34,9 +34,6 @@ export const Basin: React.FC = () => {
 
     const { isFetchingReservoirs, isGeneratingReport } = useLoading();
 
-    const controller = useRef<AbortController>(null);
-    const isMounted = useRef(true);
-
     useEffect(() => {
         if (!map) {
             return;
@@ -55,59 +52,62 @@ export const Basin: React.FC = () => {
         };
     }, [map]);
 
-    const getBasinOptions = async () => {
-        try {
-            controller.current = new AbortController();
+    useEffect(() => {
+        let isMounted = true;
 
-            const basinFeatureCollection = await geoconnexService.getItems<
-                FeatureCollection<Polygon, Huc06BasinProperties>
-            >(SourceId.Basins, {
-                params: {
-                    bbox: [-125, 24, -96.5, 49],
-                    skipGeometry: true,
-                },
-                signal: controller.current.signal,
-            });
+        const controller = new AbortController();
 
-            if (basinFeatureCollection.features.length) {
-                const basinOptions = formatOptions(
-                    basinFeatureCollection.features.filter((feature) =>
-                        ValidBasins.includes(String(feature.id))
-                    ),
-                    (feature) => String(feature.id),
-                    (feature) =>
-                        String(feature?.properties?.[Huc02BasinField.Name]),
-                    { defaultLabel: '', defaultValue: '', noDefault: true }
-                );
+        geoconnexService
+            .getItems<FeatureCollection<Polygon, Huc06BasinProperties>>(
+                SourceId.Basins,
+                {
+                    params: {
+                        bbox: [-125, 24, -96.5, 49],
+                        skipGeometry: true,
+                    },
+                    signal: controller.signal,
+                }
+            )
+            .then((featureCollection) => {
+                if (featureCollection.features.length > 0) {
+                    const basinOptions = formatOptions(
+                        featureCollection.features.filter((feature) =>
+                            ValidBasins.includes(String(feature.id))
+                        ),
+                        (feature) => String(feature.id),
+                        (feature) =>
+                            String(feature?.properties?.[Huc02BasinField.Name]),
+                        { defaultLabel: '', defaultValue: '', noDefault: true }
+                    );
 
-                setBasinOptions(basinOptions);
-
-                if (isMounted.current) {
+                    if (isMounted) {
+                        setBasinOptions(basinOptions);
+                    }
+                }
+            })
+            .catch((error) => {
+                if (
+                    (error as Error)?.name === 'AbortError' ||
+                    (typeof error === 'string' && error === 'Component unmount')
+                ) {
+                    console.log('Fetch request canceled');
+                } else {
+                    if ((error as Error)?.message) {
+                        const _error = error as Error;
+                        console.error(_error);
+                    }
+                }
+            })
+            .finally(() => {
+                if (isMounted) {
                     setLoading(false);
                 }
-            }
-        } catch (error) {
-            if (
-                (error as Error)?.name === 'AbortError' ||
-                (typeof error === 'string' && error === 'Component unmount')
-            ) {
-                console.log('Fetch request canceled');
-            } else {
-                if ((error as Error)?.message) {
-                    const _error = error as Error;
-                    console.error(_error);
-                }
-            }
-        }
-    };
+            });
 
-    useEffect(() => {
-        isMounted.current = true;
-        void getBasinOptions();
         return () => {
-            isMounted.current = false;
-            if (controller.current) {
-                controller.current.abort('Component unmount');
+            isMounted = false;
+            if (controller) {
+                controller.abort('Component unmount');
             }
         };
     }, []);
@@ -127,19 +127,13 @@ export const Basin: React.FC = () => {
                     id="basinSelector"
                     className={styles.multiselect}
                     disabled={isDisabled}
-                    searchable
                     data={basinOptions}
                     value={basin}
                     aria-label="Select a Basin"
                     placeholder="Select a basin"
                     label="Filter by Geography"
-                    onChange={(value: string[]) => {
-                        if (value) {
-                            setBasin(value);
-                        } else {
-                            setBasin([]);
-                        }
-                    }}
+                    onChange={setBasin}
+                    searchable
                     clearable
                 />
             )}

--- a/dashboard-ui/src/features/Reservoirs/Filter/Selectors/BoundingGeography.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/Selectors/BoundingGeography.tsx
@@ -22,6 +22,18 @@ export const BoundingGeometryVisibilityMap: {
     [BoundingGeographyLevel.Region]: {
         [SubLayerId.RegionsFill]: true,
         [SubLayerId.RegionsBoundary]: true,
+        [SubLayerId.ManagingRegionsFill]: true,
+        [SubLayerId.ManagingRegionsBoundary]: true,
+        [SubLayerId.BasinsFill]: false,
+        [SubLayerId.BasinsBoundary]: false,
+        [SubLayerId.StatesFill]: false,
+        [SubLayerId.StatesBoundary]: false,
+    },
+    [BoundingGeographyLevel.ManagingRegion]: {
+        [SubLayerId.RegionsFill]: false,
+        [SubLayerId.RegionsBoundary]: false,
+        [SubLayerId.ManagingRegionsFill]: true,
+        [SubLayerId.ManagingRegionsBoundary]: true,
         [SubLayerId.BasinsFill]: false,
         [SubLayerId.BasinsBoundary]: false,
         [SubLayerId.StatesFill]: false,
@@ -30,6 +42,8 @@ export const BoundingGeometryVisibilityMap: {
     [BoundingGeographyLevel.Basin]: {
         [SubLayerId.RegionsFill]: false,
         [SubLayerId.RegionsBoundary]: false,
+        [SubLayerId.ManagingRegionsFill]: true,
+        [SubLayerId.ManagingRegionsBoundary]: true,
         [SubLayerId.BasinsFill]: true,
         [SubLayerId.BasinsBoundary]: true,
         [SubLayerId.StatesFill]: false,
@@ -38,6 +52,8 @@ export const BoundingGeometryVisibilityMap: {
     [BoundingGeographyLevel.State]: {
         [SubLayerId.RegionsFill]: false,
         [SubLayerId.RegionsBoundary]: false,
+        [SubLayerId.ManagingRegionsFill]: true,
+        [SubLayerId.ManagingRegionsBoundary]: true,
         [SubLayerId.BasinsFill]: false,
         [SubLayerId.BasinsBoundary]: false,
         [SubLayerId.StatesFill]: true,
@@ -46,6 +62,8 @@ export const BoundingGeometryVisibilityMap: {
     [BoundingGeographyLevel.None]: {
         [SubLayerId.RegionsFill]: false,
         [SubLayerId.RegionsBoundary]: false,
+        [SubLayerId.ManagingRegionsFill]: true,
+        [SubLayerId.ManagingRegionsBoundary]: true,
         [SubLayerId.BasinsFill]: false,
         [SubLayerId.BasinsBoundary]: false,
         [SubLayerId.StatesFill]: false,
@@ -57,6 +75,10 @@ const data = [
     {
         value: BoundingGeographyLevel.Region,
         label: 'DOI Region',
+    },
+    {
+        value: BoundingGeographyLevel.ManagingRegion,
+        label: 'Managing Region',
     },
     {
         value: BoundingGeographyLevel.Basin,

--- a/dashboard-ui/src/features/Reservoirs/Filter/Selectors/BoundingGeography.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/Selectors/BoundingGeography.tsx
@@ -13,6 +13,7 @@ import useMainStore from '@/stores/main';
 import { useEffect } from 'react';
 import { useLoading } from '@/hooks/useLoading';
 import styles from '@/features/Reservoirs/Reservoirs.module.css';
+import { getBoundingGeographyLabel } from '@/utils/getBoundingGeographyLabel';
 
 export const BoundingGeometryVisibilityMap: {
     [key in BoundingGeographyLevel]: {
@@ -74,23 +75,23 @@ export const BoundingGeometryVisibilityMap: {
 const data = [
     {
         value: BoundingGeographyLevel.Region,
-        label: 'DOI Region',
+        label: getBoundingGeographyLabel(BoundingGeographyLevel.Region),
     },
     {
         value: BoundingGeographyLevel.ManagingRegion,
-        label: 'Managing Region',
+        label: getBoundingGeographyLabel(BoundingGeographyLevel.ManagingRegion),
     },
     {
         value: BoundingGeographyLevel.Basin,
-        label: 'Basin (HUC2)',
+        label: getBoundingGeographyLabel(BoundingGeographyLevel.Basin),
     },
     {
         value: BoundingGeographyLevel.State,
-        label: 'State',
+        label: getBoundingGeographyLabel(BoundingGeographyLevel.State),
     },
     {
         value: BoundingGeographyLevel.None,
-        label: 'None',
+        label: getBoundingGeographyLabel(BoundingGeographyLevel.None),
     },
 ];
 

--- a/dashboard-ui/src/features/Reservoirs/Filter/Selectors/BoundingGeography.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/Selectors/BoundingGeography.tsx
@@ -22,8 +22,8 @@ export const BoundingGeometryVisibilityMap: {
     [BoundingGeographyLevel.Region]: {
         [SubLayerId.RegionsFill]: true,
         [SubLayerId.RegionsBoundary]: true,
-        [SubLayerId.ManagingRegionsFill]: true,
-        [SubLayerId.ManagingRegionsBoundary]: true,
+        [SubLayerId.ManagingRegionsFill]: false,
+        [SubLayerId.ManagingRegionsBoundary]: false,
         [SubLayerId.BasinsFill]: false,
         [SubLayerId.BasinsBoundary]: false,
         [SubLayerId.StatesFill]: false,
@@ -42,8 +42,8 @@ export const BoundingGeometryVisibilityMap: {
     [BoundingGeographyLevel.Basin]: {
         [SubLayerId.RegionsFill]: false,
         [SubLayerId.RegionsBoundary]: false,
-        [SubLayerId.ManagingRegionsFill]: true,
-        [SubLayerId.ManagingRegionsBoundary]: true,
+        [SubLayerId.ManagingRegionsFill]: false,
+        [SubLayerId.ManagingRegionsBoundary]: false,
         [SubLayerId.BasinsFill]: true,
         [SubLayerId.BasinsBoundary]: true,
         [SubLayerId.StatesFill]: false,
@@ -52,8 +52,8 @@ export const BoundingGeometryVisibilityMap: {
     [BoundingGeographyLevel.State]: {
         [SubLayerId.RegionsFill]: false,
         [SubLayerId.RegionsBoundary]: false,
-        [SubLayerId.ManagingRegionsFill]: true,
-        [SubLayerId.ManagingRegionsBoundary]: true,
+        [SubLayerId.ManagingRegionsFill]: false,
+        [SubLayerId.ManagingRegionsBoundary]: false,
         [SubLayerId.BasinsFill]: false,
         [SubLayerId.BasinsBoundary]: false,
         [SubLayerId.StatesFill]: true,
@@ -62,8 +62,8 @@ export const BoundingGeometryVisibilityMap: {
     [BoundingGeographyLevel.None]: {
         [SubLayerId.RegionsFill]: false,
         [SubLayerId.RegionsBoundary]: false,
-        [SubLayerId.ManagingRegionsFill]: true,
-        [SubLayerId.ManagingRegionsBoundary]: true,
+        [SubLayerId.ManagingRegionsFill]: false,
+        [SubLayerId.ManagingRegionsBoundary]: false,
         [SubLayerId.BasinsFill]: false,
         [SubLayerId.BasinsBoundary]: false,
         [SubLayerId.StatesFill]: false,

--- a/dashboard-ui/src/features/Reservoirs/Filter/Selectors/ManagingRegion.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/Selectors/ManagingRegion.tsx
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2025 Lincoln Institute of Land Policy
+ * SPDX-License-Identifier: MIT
+ */
+
+'use client';
+
+import { MultiSelect, Skeleton } from '@mantine/core';
+import useMainStore from '@/stores/main';
+import { useMap } from '@/contexts/MapContexts';
+import { MAP_ID, SourceId } from '@/features/Map/consts';
+import { useEffect, useRef, useState } from 'react';
+import styles from '@/features/Reservoirs/Reservoirs.module.css';
+import { formatOptions } from '@/features/Reservoirs/Filter/Selectors/utils';
+import { FeatureCollection, Polygon } from 'geojson';
+import { SourceDataEvent } from '@/features/Map/types';
+import { isSourceDataLoaded } from '@/features/Map/utils';
+import { useLoading } from '@/hooks/useLoading';
+import wwdhService from '@/services/init/wwdh.init';
+import {
+    ManagingRegionField,
+    ManagingRegionProperties,
+} from '@/features/Map/types/managingRegion';
+
+export const ManagingRegion: React.FC = () => {
+    const { map } = useMap(MAP_ID);
+
+    const managingRegion = useMainStore((state) => state.managingRegion);
+    const setManagingRegion = useMainStore((state) => state.setManagingRegion);
+    const managingRegionOptions = useMainStore(
+        (state) => state.managingRegionOptions
+    );
+    const setManagingRegionOptions = useMainStore(
+        (state) => state.setManagingRegionOptions
+    );
+
+    const [loading, setLoading] = useState(true);
+
+    const { isFetchingReservoirs, isGeneratingReport } = useLoading();
+
+    const controller = useRef<AbortController>(null);
+    const isMounted = useRef(true);
+
+    useEffect(() => {
+        if (!map) {
+            return;
+        }
+        // Ensure both map and populating fetch are finished
+        const sourceCallback = (e: SourceDataEvent) => {
+            if (isSourceDataLoaded(map, SourceId.ManagingRegions, e)) {
+                map.off('sourcedata', sourceCallback); //remove event listener
+            }
+        };
+
+        map.on('sourcedata', sourceCallback);
+
+        return () => {
+            map.off('sourcedata', sourceCallback);
+        };
+    }, [map]);
+
+    const getBasinOptions = async () => {
+        try {
+            controller.current = new AbortController();
+
+            const managingRegionCollection = await wwdhService.getItems<
+                FeatureCollection<Polygon, ManagingRegionProperties>
+            >(SourceId.ManagingRegions, {
+                params: {
+                    f: 'json',
+                },
+                signal: controller.current.signal,
+            });
+
+            console.log('HERE', managingRegionCollection);
+
+            if (managingRegionCollection.features.length) {
+                const basinOptions = formatOptions(
+                    managingRegionCollection.features,
+                    (feature) => String(feature.id),
+                    (feature) =>
+                        String(feature?.properties?.[ManagingRegionField.Name]),
+                    { defaultLabel: '', defaultValue: '', noDefault: true }
+                );
+
+                setManagingRegionOptions(basinOptions);
+
+                if (isMounted.current) {
+                    setLoading(false);
+                }
+            }
+        } catch (error) {
+            if (
+                (error as Error)?.name === 'AbortError' ||
+                (typeof error === 'string' && error === 'Component unmount')
+            ) {
+                console.log('Fetch request canceled');
+            } else {
+                if ((error as Error)?.message) {
+                    const _error = error as Error;
+                    console.error(_error);
+                }
+            }
+        }
+    };
+
+    useEffect(() => {
+        isMounted.current = true;
+        void getBasinOptions();
+        return () => {
+            isMounted.current = false;
+            if (controller.current) {
+                controller.current.abort('Component unmount');
+            }
+        };
+    }, []);
+
+    const isDisabled = isFetchingReservoirs || isGeneratingReport;
+
+    return (
+        <>
+            {loading || managingRegionOptions.length === 0 ? (
+                <Skeleton
+                    height={54} // Default dimensions of select
+                    width={155}
+                />
+            ) : (
+                <MultiSelect
+                    size="xs"
+                    id="managingRegionSelector"
+                    className={styles.multiselect}
+                    disabled={isDisabled}
+                    searchable
+                    data={managingRegionOptions}
+                    value={managingRegion}
+                    aria-label="Select a Region"
+                    placeholder="Select a region"
+                    label="Filter by Managing Region"
+                    onChange={(value: string[]) => {
+                        if (value) {
+                            setManagingRegion(value);
+                        } else {
+                            setManagingRegion([]);
+                        }
+                    }}
+                    clearable
+                />
+            )}
+        </>
+    );
+};

--- a/dashboard-ui/src/features/Reservoirs/Filter/Selectors/ManagingRegion.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/Selectors/ManagingRegion.tsx
@@ -9,7 +9,7 @@ import { MultiSelect, Skeleton } from '@mantine/core';
 import useMainStore from '@/stores/main';
 import { useMap } from '@/contexts/MapContexts';
 import { MAP_ID, SourceId } from '@/features/Map/consts';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import styles from '@/features/Reservoirs/Reservoirs.module.css';
 import { formatOptions } from '@/features/Reservoirs/Filter/Selectors/utils';
 import { FeatureCollection, Polygon } from 'geojson';
@@ -38,9 +38,6 @@ export const ManagingRegion: React.FC = () => {
 
     const { isFetchingReservoirs, isGeneratingReport } = useLoading();
 
-    const controller = useRef<AbortController>(null);
-    const isMounted = useRef(true);
-
     useEffect(() => {
         if (!map) {
             return;
@@ -59,61 +56,66 @@ export const ManagingRegion: React.FC = () => {
         };
     }, [map]);
 
-    const getBasinOptions = async () => {
-        try {
-            controller.current = new AbortController();
+    useEffect(() => {
+        let isMounted = true;
 
-            const managingRegionCollection = await wwdhService.getItems<
-                FeatureCollection<Polygon, ManagingRegionProperties>
-            >(SourceId.ManagingRegions, {
-                params: {
-                    f: 'json',
-                },
-                signal: controller.current.signal,
-            });
+        const controller = new AbortController();
 
-            if (managingRegionCollection.features.length) {
-                const basinOptions = formatOptions(
-                    managingRegionCollection.features,
-                    (feature) =>
-                        String(
-                            feature?.properties?.[
-                                ManagingRegionField.RegionAbbreviation
-                            ]
-                        ),
-                    (feature) =>
-                        String(feature?.properties?.[ManagingRegionField.Name]),
-                    { defaultLabel: '', defaultValue: '', noDefault: true }
-                );
+        wwdhService
+            .getItems<FeatureCollection<Polygon, ManagingRegionProperties>>(
+                SourceId.ManagingRegions,
+                {
+                    params: {
+                        f: 'json',
+                    },
+                    signal: controller.signal,
+                }
+            )
+            .then((featureCollection) => {
+                if (featureCollection.features.length > 0) {
+                    const managingRegionOptions = formatOptions(
+                        featureCollection.features,
+                        (feature) =>
+                            String(
+                                feature?.properties?.[
+                                    ManagingRegionField.RegionAbbreviation
+                                ]
+                            ),
+                        (feature) =>
+                            String(
+                                feature?.properties?.[ManagingRegionField.Name]
+                            ),
+                        { defaultLabel: '', defaultValue: '', noDefault: true }
+                    );
 
-                setManagingRegionOptions(basinOptions);
-
-                if (isMounted.current) {
+                    if (isMounted) {
+                        setManagingRegionOptions(managingRegionOptions);
+                    }
+                }
+            })
+            .catch((error) => {
+                if (
+                    (error as Error)?.name === 'AbortError' ||
+                    (typeof error === 'string' && error === 'Component unmount')
+                ) {
+                    console.log('Fetch request canceled');
+                } else {
+                    if ((error as Error)?.message) {
+                        const _error = error as Error;
+                        console.error(_error);
+                    }
+                }
+            })
+            .finally(() => {
+                if (isMounted) {
                     setLoading(false);
                 }
-            }
-        } catch (error) {
-            if (
-                (error as Error)?.name === 'AbortError' ||
-                (typeof error === 'string' && error === 'Component unmount')
-            ) {
-                console.log('Fetch request canceled');
-            } else {
-                if ((error as Error)?.message) {
-                    const _error = error as Error;
-                    console.error(_error);
-                }
-            }
-        }
-    };
+            });
 
-    useEffect(() => {
-        isMounted.current = true;
-        void getBasinOptions();
         return () => {
-            isMounted.current = false;
-            if (controller.current) {
-                controller.current.abort('Component unmount');
+            isMounted = false;
+            if (controller) {
+                controller.abort('Component unmount');
             }
         };
     }, []);
@@ -133,19 +135,13 @@ export const ManagingRegion: React.FC = () => {
                     id="managingRegionSelector"
                     className={styles.multiselect}
                     disabled={isDisabled}
-                    searchable
                     data={managingRegionOptions}
                     value={managingRegion}
                     aria-label="Select a Region"
                     placeholder="Select a region"
                     label="Filter by Region"
-                    onChange={(value: string[]) => {
-                        if (value) {
-                            setManagingRegion(value);
-                        } else {
-                            setManagingRegion([]);
-                        }
-                    }}
+                    onChange={setManagingRegion}
+                    searchable
                     clearable
                 />
             )}

--- a/dashboard-ui/src/features/Reservoirs/Filter/Selectors/ManagingRegion.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/Selectors/ManagingRegion.tsx
@@ -72,12 +72,15 @@ export const ManagingRegion: React.FC = () => {
                 signal: controller.current.signal,
             });
 
-            console.log('HERE', managingRegionCollection);
-
             if (managingRegionCollection.features.length) {
                 const basinOptions = formatOptions(
                     managingRegionCollection.features,
-                    (feature) => String(feature.id),
+                    (feature) =>
+                        String(
+                            feature?.properties?.[
+                                ManagingRegionField.RegionAbbreviation
+                            ]
+                        ),
                     (feature) =>
                         String(feature?.properties?.[ManagingRegionField.Name]),
                     { defaultLabel: '', defaultValue: '', noDefault: true }
@@ -135,7 +138,7 @@ export const ManagingRegion: React.FC = () => {
                     value={managingRegion}
                     aria-label="Select a Region"
                     placeholder="Select a region"
-                    label="Filter by Managing Region"
+                    label="Filter by Region"
                     onChange={(value: string[]) => {
                         if (value) {
                             setManagingRegion(value);

--- a/dashboard-ui/src/features/Reservoirs/Filter/Selectors/Region.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/Selectors/Region.tsx
@@ -7,7 +7,7 @@
 
 import { MultiSelect, Skeleton } from '@mantine/core';
 import useMainStore from '@/stores/main';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { formatOptions } from '@/features/Reservoirs/Filter/Selectors/utils';
 import esriService from '@/services/init/esri.init';
 import { MAP_ID, SourceId } from '@/features/Map/consts';
@@ -36,9 +36,6 @@ export const Region: React.FC = () => {
 
     const { isFetchingReservoirs, isGeneratingReport } = useLoading();
 
-    const controller = useRef<AbortController>(null);
-    const isMounted = useRef(true);
-
     const { map } = useMap(MAP_ID);
 
     useEffect(() => {
@@ -49,7 +46,6 @@ export const Region: React.FC = () => {
         // Ensure both map and populating fetch are finished
         const sourceCallback = (e: SourceDataEvent) => {
             if (isSourceDataLoaded(map, SourceId.Regions, e)) {
-                setLoading(false);
                 map.off('sourcedata', sourceCallback); //remove event listener
             }
         };
@@ -61,58 +57,61 @@ export const Region: React.FC = () => {
         };
     }, [map]);
 
-    const getRegionOptions = async () => {
-        try {
-            controller.current = new AbortController();
-
-            const regionFeatureCollection = await esriService.getFeatures(
-                controller.current.signal
-            );
-
-            if (regionFeatureCollection.features.length) {
-                const regionOptions = formatOptions(
-                    regionFeatureCollection.features.filter((feature) =>
-                        [5, 6, 7, 8, 9, 10].includes(
-                            feature.properties![RegionField.RegNum] as number
-                        )
-                    ),
-                    (feature) =>
-                        fixLabel(
-                            String(feature?.properties?.[RegionField.Name])
-                        ),
-                    (feature) =>
-                        fixLabel(
-                            String(feature?.properties?.[RegionField.Name])
-                        ),
-                    { defaultLabel: '', defaultValue: '', noDefault: true }
-                );
-
-                if (isMounted.current) {
-                    setRegionOptions(regionOptions);
-                }
-            }
-        } catch (error) {
-            if (
-                (error as Error)?.name === 'AbortError' ||
-                (typeof error === 'string' && error === 'Component unmount')
-            ) {
-                console.log('Fetch request canceled');
-            } else {
-                if ((error as Error)?.message) {
-                    const _error = error as Error;
-                    console.error(_error);
-                }
-            }
-        }
-    };
-
     useEffect(() => {
-        isMounted.current = true;
-        void getRegionOptions();
+        let isMounted = true;
+
+        const controller = new AbortController();
+        esriService
+            .getFeatures(controller.signal)
+            .then((featureCollection) => {
+                if (featureCollection.features.length > 0) {
+                    const regionOptions = formatOptions(
+                        featureCollection.features.filter((feature) =>
+                            [5, 6, 7, 8, 9, 10].includes(
+                                feature.properties![
+                                    RegionField.RegNum
+                                ] as number
+                            )
+                        ),
+                        (feature) =>
+                            fixLabel(
+                                String(feature?.properties?.[RegionField.Name])
+                            ),
+                        (feature) =>
+                            fixLabel(
+                                String(feature?.properties?.[RegionField.Name])
+                            ),
+                        { defaultLabel: '', defaultValue: '', noDefault: true }
+                    );
+
+                    if (isMounted) {
+                        setRegionOptions(regionOptions);
+                    }
+                }
+            })
+            .catch((error) => {
+                if (
+                    (error as Error)?.name === 'AbortError' ||
+                    (typeof error === 'string' && error === 'Component unmount')
+                ) {
+                    console.log('Fetch request canceled');
+                } else {
+                    if ((error as Error)?.message) {
+                        const _error = error as Error;
+                        console.error(_error);
+                    }
+                }
+            })
+            .finally(() => {
+                if (isMounted) {
+                    setLoading(false);
+                }
+            });
+
         return () => {
-            isMounted.current = false;
-            if (controller.current) {
-                controller.current.abort('Component unmount');
+            isMounted = false;
+            if (controller) {
+                controller.abort('Component unmount');
             }
         };
     }, []);
@@ -138,13 +137,7 @@ export const Region: React.FC = () => {
                     aria-label="Select a region"
                     placeholder="Select a region"
                     label="Filter by Region"
-                    onChange={(value: string[]) => {
-                        if (value) {
-                            setRegion(value);
-                        } else {
-                            setRegion([]);
-                        }
-                    }}
+                    onChange={setRegion}
                     searchable
                     clearable
                 />

--- a/dashboard-ui/src/features/Reservoirs/Filter/Selectors/State.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/Selectors/State.tsx
@@ -8,7 +8,7 @@
 import { MultiSelect, Skeleton } from '@mantine/core';
 import { useMap } from '@/contexts/MapContexts';
 import { MAP_ID, SourceId, ValidStates } from '@/features/Map/consts';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import styles from '@/features/Reservoirs/Reservoirs.module.css';
 import { SourceDataEvent } from '@/features/Map/types';
 import { isSourceDataLoaded } from '@/features/Map/utils';
@@ -31,9 +31,6 @@ export const State: React.FC = () => {
 
     const { isFetchingReservoirs, isGeneratingReport } = useLoading();
 
-    const controller = useRef<AbortController>(null);
-    const isMounted = useRef(true);
-
     useEffect(() => {
         if (!map) {
             return;
@@ -53,58 +50,65 @@ export const State: React.FC = () => {
         };
     }, [map]);
 
-    const getBasinOptions = async () => {
-        try {
-            controller.current = new AbortController();
+    useEffect(() => {
+        let isMounted = true;
 
-            const stateFeatureCollection = await geoconnexService.getItems<
-                FeatureCollection<Polygon, StateProperties>
-            >(SourceId.States, {
-                params: {
-                    bbox: [-125, 24, -96.5, 49],
-                    skipGeometry: true,
-                },
-                signal: controller.current.signal,
+        const controller = new AbortController();
+
+        geoconnexService
+            .getItems<FeatureCollection<Polygon, StateProperties>>(
+                SourceId.States,
+                {
+                    params: {
+                        bbox: [-125, 24, -96.5, 49],
+                        skipGeometry: true,
+                    },
+                    signal: controller.signal,
+                }
+            )
+            .then((featureCollection) => {
+                if (featureCollection.features.length > 0) {
+                    const stateOptions = formatOptions(
+                        featureCollection.features.filter((feature) =>
+                            ValidStates.includes(
+                                feature.properties[StateField.Acronym]
+                            )
+                        ),
+                        (feature) =>
+                            String(feature?.properties?.[StateField.Uri]),
+                        (feature) =>
+                            String(feature?.properties?.[StateField.Name]),
+                        { defaultLabel: '', defaultValue: '', noDefault: true }
+                    );
+
+                    if (isMounted) {
+                        setStateOptions(stateOptions);
+                    }
+                }
+            })
+            .catch((error) => {
+                if (
+                    (error as Error)?.name === 'AbortError' ||
+                    (typeof error === 'string' && error === 'Component unmount')
+                ) {
+                    console.log('Fetch request canceled');
+                } else {
+                    if ((error as Error)?.message) {
+                        const _error = error as Error;
+                        console.error(_error);
+                    }
+                }
+            })
+            .finally(() => {
+                if (isMounted) {
+                    setLoading(false);
+                }
             });
 
-            if (stateFeatureCollection.features.length) {
-                const basinOptions = formatOptions(
-                    stateFeatureCollection.features.filter((feature) =>
-                        ValidStates.includes(
-                            feature.properties[StateField.Acronym]
-                        )
-                    ),
-                    (feature) => String(feature?.properties?.[StateField.Uri]),
-                    (feature) => String(feature?.properties?.[StateField.Name]),
-                    { defaultLabel: '', defaultValue: '', noDefault: true }
-                );
-
-                if (isMounted.current) {
-                    setStateOptions(basinOptions);
-                }
-            }
-        } catch (error) {
-            if (
-                (error as Error)?.name === 'AbortError' ||
-                (typeof error === 'string' && error === 'Component unmount')
-            ) {
-                console.log('Fetch request canceled');
-            } else {
-                if ((error as Error)?.message) {
-                    const _error = error as Error;
-                    console.error(_error);
-                }
-            }
-        }
-    };
-
-    useEffect(() => {
-        isMounted.current = true;
-        void getBasinOptions();
         return () => {
-            isMounted.current = false;
-            if (controller.current) {
-                controller.current.abort('Component unmount');
+            isMounted = false;
+            if (controller) {
+                controller.abort('Component unmount');
             }
         };
     }, []);
@@ -129,13 +133,7 @@ export const State: React.FC = () => {
                     aria-label="Select a State"
                     placeholder="Select a State"
                     label="Filter by State"
-                    onChange={(_value) => {
-                        if (_value) {
-                            setState(_value);
-                        } else {
-                            setState([]);
-                        }
-                    }}
+                    onChange={setState}
                     searchable
                     clearable
                 />

--- a/dashboard-ui/src/features/Reservoirs/Filter/index.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/index.tsx
@@ -26,6 +26,7 @@ import Up from '@/icons/Up';
 import FilterIcon from '@/icons/Filter';
 import { useLoading } from '@/hooks/useLoading';
 import { ReservoirDateSelector } from '@/features/Reservoirs/ReservoirDateSelector';
+import { ManagingRegion } from './Selectors/ManagingRegion';
 
 type Props = {
     search: string;
@@ -70,6 +71,8 @@ export const Filter: React.FC<Props> = (props) => {
         switch (boundingGeographyLevel) {
             case BoundingGeographyLevel.Region:
                 return 'Show Region Labels';
+            case BoundingGeographyLevel.ManagingRegion:
+                return 'Show Managing Region Labels';
             case BoundingGeographyLevel.Basin:
                 return 'Show Basin Labels';
             case BoundingGeographyLevel.State:
@@ -116,6 +119,17 @@ export const Filter: React.FC<Props> = (props) => {
                     }}
                 >
                     <Region />
+                </Box>
+                <Box
+                    style={{
+                        display:
+                            boundingGeographyLevel ===
+                            BoundingGeographyLevel.ManagingRegion
+                                ? 'block'
+                                : 'none',
+                    }}
+                >
+                    <ManagingRegion />
                 </Box>
                 <Box
                     style={{

--- a/dashboard-ui/src/features/Reservoirs/Filter/index.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/index.tsx
@@ -27,6 +27,7 @@ import FilterIcon from '@/icons/Filter';
 import { useLoading } from '@/hooks/useLoading';
 import { ReservoirDateSelector } from '@/features/Reservoirs/ReservoirDateSelector';
 import { ManagingRegion } from './Selectors/ManagingRegion';
+import { getBoundingGeographyLabel } from '@/utils/getBoundingGeographyLabel';
 
 type Props = {
     search: string;
@@ -68,19 +69,7 @@ export const Filter: React.FC<Props> = (props) => {
     };
 
     const getLabel = (boundingGeographyLevel: BoundingGeographyLevel) => {
-        switch (boundingGeographyLevel) {
-            case BoundingGeographyLevel.Region:
-                return 'Show Region Labels';
-            case BoundingGeographyLevel.ManagingRegion:
-                return 'Show Managing Region Labels';
-            case BoundingGeographyLevel.Basin:
-                return 'Show Basin Labels';
-            case BoundingGeographyLevel.State:
-                return 'Show State Labels';
-            case BoundingGeographyLevel.None:
-            default:
-                return 'Show Labels';
-        }
+        return `Show ${getBoundingGeographyLabel(boundingGeographyLevel)} Labels`;
     };
 
     const isDisabled = isFetchingReservoirs || isGeneratingReport;

--- a/dashboard-ui/src/features/Reservoirs/Filter/index.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Filter/index.tsx
@@ -26,7 +26,7 @@ import Up from '@/icons/Up';
 import FilterIcon from '@/icons/Filter';
 import { useLoading } from '@/hooks/useLoading';
 import { ReservoirDateSelector } from '@/features/Reservoirs/ReservoirDateSelector';
-import { ManagingRegion } from './Selectors/ManagingRegion';
+import { ManagingRegion } from '@/features/Reservoirs/Filter/Selectors/ManagingRegion';
 import { getBoundingGeographyLabel } from '@/utils/getBoundingGeographyLabel';
 
 type Props = {
@@ -93,11 +93,7 @@ export const Filter: React.FC<Props> = (props) => {
             </Group>
             <ReservoirDateSelector />
             <Divider my="calc(var(--default-spacing) / 2)" />
-            <Group
-                gap="var(--default-spacing)"
-                align="flex-start"
-                wrap="nowrap"
-            >
+            <Group gap="var(--default-spacing)" align="flex-end" wrap="nowrap">
                 <Box
                     style={{
                         display:

--- a/dashboard-ui/src/features/Reservoirs/Report/TooltipDetail.tsx
+++ b/dashboard-ui/src/features/Reservoirs/Report/TooltipDetail.tsx
@@ -39,6 +39,9 @@ export const TooltipDetail: React.FC<Props> = (props) => {
     const { filters } = props;
 
     const regionOptions = useMainStore((state) => state.regionOptions);
+    const managingRegionOptions = useMainStore(
+        (state) => state.managingRegionOptions
+    );
     const basinOptions = useMainStore((state) => state.basinOptions);
     const stateOptions = useMainStore((state) => state.stateOptions);
 
@@ -64,6 +67,14 @@ export const TooltipDetail: React.FC<Props> = (props) => {
         if (filters.region.length > 0) {
             const labels = getLabels(filters.region, regionOptions);
             bullets.push(getGeoBoundBullet(labels, 'region'));
+        }
+
+        if (filters.managingRegion.length > 0) {
+            const labels = getLabels(
+                filters.managingRegion,
+                managingRegionOptions
+            );
+            bullets.push(getGeoBoundBullet(labels, 'managing region'));
         }
 
         if (filters.basin.length > 0) {

--- a/dashboard-ui/src/features/Reservoirs/index.tsx
+++ b/dashboard-ui/src/features/Reservoirs/index.tsx
@@ -38,6 +38,7 @@ const Reservoirs: React.FC<Props> = (props) => {
     const { accessToken } = props;
 
     const region = useMainStore((state) => state.region);
+    const managingRegion = useMainStore((state) => state.managingRegion);
     const basin = useMainStore((state) => state.basin);
     const state = useMainStore((state) => state.state);
 
@@ -132,6 +133,9 @@ const Reservoirs: React.FC<Props> = (props) => {
                         const regionConnector = getString(
                             config.regionConnectorProperty
                         );
+                        const managingRegionConnector = getString(
+                            config.managingRegionConnectorProperty
+                        );
                         const basinConnector = getString(
                             config.basinConnectorProperty
                         );
@@ -161,6 +165,7 @@ const Reservoirs: React.FC<Props> = (props) => {
                                 percentFull: (storage / capacity) * 100,
                                 percentAverage: (storage / average) * 100,
                                 sourceId: collectionId,
+                                managingRegionConnector,
                                 regionConnector,
                                 basinConnector,
                                 stateConnector,
@@ -198,6 +203,14 @@ const Reservoirs: React.FC<Props> = (props) => {
             );
         }
 
+        if (managingRegion.length > 0) {
+            filterFunctions.push((feature) =>
+                managingRegion.includes(
+                    feature.properties.managingRegionConnector
+                )
+            );
+        }
+
         if (basin.length > 0) {
             filterFunctions.push((feature) =>
                 basin.includes(feature.properties.basinConnector.slice(0, 2))
@@ -221,6 +234,7 @@ const Reservoirs: React.FC<Props> = (props) => {
         organizedReservoirs,
         search,
         region,
+        managingRegion,
         basin,
         state,
         sortBy,
@@ -385,6 +399,7 @@ const Reservoirs: React.FC<Props> = (props) => {
                         hideNoData,
                         limitByExtent,
                         region,
+                        managingRegion,
                         basin,
                         state,
                     }}

--- a/dashboard-ui/src/features/Reservoirs/types.ts
+++ b/dashboard-ui/src/features/Reservoirs/types.ts
@@ -28,6 +28,7 @@ export type OrganizedProperties = {
     percentFull: number;
     percentAverage: number;
     regionConnector: string;
+    managingRegionConnector: string;
     basinConnector: string;
     stateConnector: string;
     sourceId: string;
@@ -42,6 +43,7 @@ export type Filters = {
     hideNoData: boolean;
     limitByExtent: boolean;
     region: string[];
+    managingRegion: string[];
     basin: string[];
     state: string[];
 };

--- a/dashboard-ui/src/stores/main/index.ts
+++ b/dashboard-ui/src/stores/main/index.ts
@@ -21,6 +21,13 @@ export interface MainState {
     setRegion: (region: MainState['region']) => void;
     regionOptions: ComboboxItem[];
     setRegionOptions: (regionOptions: MainState['regionOptions']) => void;
+    // Selected Region filter
+    managingRegion: string[];
+    setManagingRegion: (region: MainState['managingRegion']) => void;
+    managingRegionOptions: ComboboxItem[];
+    setManagingRegionOptions: (
+        regionOptions: MainState['managingRegionOptions']
+    ) => void;
     // Selected Basin
     basin: string[];
     setBasin: (basin: MainState['basin']) => void;
@@ -63,6 +70,7 @@ export interface MainState {
         [LayerId.NOAAPrecipSixToTen]: boolean;
         [LayerId.NOAATempSixToTen]: boolean;
         [LayerId.RegionsReference]: boolean;
+        [LayerId.ManagingRegionsReference]: boolean;
         [LayerId.BasinsReference]: boolean;
         [LayerId.StatesReference]: boolean;
     };
@@ -89,6 +97,11 @@ const useMainStore = create<MainState>()((set) => ({
     setRegion: (region) => set({ region }),
     regionOptions: [],
     setRegionOptions: (regionOptions) => set({ regionOptions }),
+    managingRegion: [],
+    setManagingRegion: (managingRegion) => set({ managingRegion }),
+    managingRegionOptions: [],
+    setManagingRegionOptions: (managingRegionOptions) =>
+        set({ managingRegionOptions }),
     basin: [],
     setBasin: (basin) => set({ basin }),
     basinOptions: [],
@@ -118,6 +131,7 @@ const useMainStore = create<MainState>()((set) => ({
         [LayerId.NOAAPrecipSixToTen]: false,
         [LayerId.NOAATempSixToTen]: false,
         [LayerId.RegionsReference]: false,
+        [LayerId.ManagingRegionsReference]: false,
         [LayerId.BasinsReference]: false,
         [LayerId.StatesReference]: false,
     },

--- a/dashboard-ui/src/stores/main/types.ts
+++ b/dashboard-ui/src/stores/main/types.ts
@@ -22,6 +22,7 @@ export type Reservoir = {
 
 export enum BoundingGeographyLevel {
     Region = 'region',
+    ManagingRegion = 'managing-region',
     Basin = 'basin',
     State = 'state',
     None = 'none',

--- a/dashboard-ui/src/utils/getBoundingGeographyLabel.ts
+++ b/dashboard-ui/src/utils/getBoundingGeographyLabel.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2026 Lincoln Institute of Land Policy
+ * SPDX-License-Identifier: MIT
+ */
+
+import { BoundingGeographyLevel } from '@/stores/main/types';
+
+export const getBoundingGeographyLabel = (
+    boundingGeographyLevel: BoundingGeographyLevel
+) => {
+    switch (boundingGeographyLevel) {
+        case BoundingGeographyLevel.Region:
+            return 'DOI Region';
+        case BoundingGeographyLevel.ManagingRegion:
+            return 'Managing Region';
+        case BoundingGeographyLevel.Basin:
+            return 'Basin (HUC2)';
+        case BoundingGeographyLevel.State:
+            return 'State';
+        case BoundingGeographyLevel.None:
+            return 'None';
+        default:
+            return 'Boundary';
+    }
+};


### PR DESCRIPTION
### **Description**
Adds support for the new managing region boundaries. Also standardizes some repeated logic and adds a legend entry for filter boundaries.

### **AC**
- [x] Selecting the Managing Regions radio option:
    - [x] shows the managing region boundaries
    - [x] Shows a dropdown that can be used to filter boundaries and reservoirs in both map and table
    - [x] Shows a legend entry for Managing Regions
- [x] Includes another reference layer in the Reference Data accordion for Managing Region boundaries
    - [x] reference layer shows in legend
- [x] Entry for Managing Regions in Documentation tab of about modal
- [x] Radio buttons, reference layer labels, and legend entries all have appropriate labels for DOI Region, Managing Region, Basin (HUC2) and State
- [x] Layers in Reference Data accordion render as expected when toggled on/off
