### PR TITLE
Show all high capacity reservoirs, fix mismatch with label show, clean up hook use, impr perf

### DIFF
--- a/dashboard-ui/src/features/Map/index.tsx
+++ b/dashboard-ui/src/features/Map/index.tsx
@@ -170,7 +170,7 @@ const MainMap: React.FC<Props> = (props) => {
         }
     }, [isMounted, setMapMoved]);
 
-    const throttledHandleMapMove = useMemo(
+    const debouncedHandleMapMove = useMemo(
         () => debounce(handleMapMove, 150),
         [handleMapMove]
     );
@@ -222,15 +222,15 @@ const MainMap: React.FC<Props> = (props) => {
             return;
         }
 
-        map.on('moveend', throttledHandleMapMove);
-        map.on('zoomend', throttledHandleMapMove);
+        map.on('moveend', debouncedHandleMapMove);
+        map.on('zoomend', debouncedHandleMapMove);
 
         return () => {
-            map.off('moveend', throttledHandleMapMove);
-            map.off('zoomend', throttledHandleMapMove);
-            throttledHandleMapMove.cancel();
+            map.off('moveend', debouncedHandleMapMove);
+            map.off('zoomend', debouncedHandleMapMove);
+            debouncedHandleMapMove.cancel();
         };
-    }, [map, throttledHandleMapMove]);
+    }, [map, debouncedHandleMapMove]);
 
     useEffect(() => {
         if (!map) {
@@ -303,8 +303,6 @@ const MainMap: React.FC<Props> = (props) => {
                 animate: false,
             }
         );
-
-        return () => {};
     }, [map]);
 
     useEffect(() => {

--- a/dashboard-ui/src/features/Map/index.tsx
+++ b/dashboard-ui/src/features/Map/index.tsx
@@ -6,7 +6,13 @@
 'use client';
 
 import Map from '@/components/Map';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 import { layerDefinitions, sourceConfigs } from '@/features/Map/config';
 import {
     MAP_ID,
@@ -50,7 +56,6 @@ import { StateField } from '@/features/Map/types/state';
 import { Huc02BasinField } from '@/features/Map/types/basin';
 import { BoundingGeographyLevel } from '@/stores/main/types';
 import useSessionStore from '@/stores/session';
-import debounce from 'lodash.debounce';
 import { SpriteService } from '@/services/sprite/sprite.service';
 import { useHistoricalData } from '@/hooks/useHistoricalData';
 import { customLoader } from '@/services/sprite/customLoader';
@@ -58,6 +63,7 @@ import { ReservoirConfigId } from '@/features/Map/types';
 import { useMediaQuery } from '@mantine/hooks';
 import { MOBILE_MEDIA_QUERY } from '@/features/Main/consts';
 import { ManagingRegionField } from './types/managingRegion';
+import debounce from 'lodash.debounce';
 
 type Props = {
     accessToken: string;
@@ -164,13 +170,14 @@ const MainMap: React.FC<Props> = (props) => {
         }
     }, [isMounted, setMapMoved]);
 
-    const debouncedHandleMapMove = useCallback(debounce(handleMapMove, 150), [
-        handleMapMove,
-    ]);
+    const throttledHandleMapMove = useMemo(
+        () => debounce(handleMapMove, 150),
+        [handleMapMove]
+    );
 
-    const debouncedHandleMapZoom = useCallback(
-        debounce(updateReservoirFilters, 75),
-        [updateReservoirFilters]
+    const debouncedHandleMapZoom = useMemo(
+        () => debounce(() => updateReservoirFilters(map), 250),
+        [map, updateReservoirFilters]
     );
 
     const loadSpriteSheet = async () => {
@@ -211,12 +218,32 @@ const MainMap: React.FC<Props> = (props) => {
     }, [map, isSpritesheetReady]);
 
     useEffect(() => {
+        if (!map) {
+            return;
+        }
+
+        map.on('moveend', throttledHandleMapMove);
+        map.on('zoomend', throttledHandleMapMove);
+
         return () => {
-            debouncedHandleMapMove.cancel();
-            debouncedHandleMapZoom.cancel();
-            isMounted.current = false;
+            map.off('moveend', throttledHandleMapMove);
+            map.off('zoomend', throttledHandleMapMove);
+            throttledHandleMapMove.cancel();
         };
-    }, [debouncedHandleMapMove, debouncedHandleMapZoom]);
+    }, [map, throttledHandleMapMove]);
+
+    useEffect(() => {
+        if (!map) {
+            return;
+        }
+
+        map.on('zoom', debouncedHandleMapZoom);
+
+        return () => {
+            map.off('zoom', debouncedHandleMapZoom);
+            debouncedHandleMapZoom.cancel();
+        };
+    }, [map, debouncedHandleMapZoom]);
 
     useEffect(() => {
         setShouldResize(loadingInstances.length > 0);
@@ -259,18 +286,10 @@ const MainMap: React.FC<Props> = (props) => {
             return;
         }
 
-        // Detect map movements, update features connected to map extent
-        map.on('moveend', debouncedHandleMapMove);
-        map.on('zoomend', debouncedHandleMapMove);
-
         loadImages(map);
         map.on('style.load', () => {
             loadImages(map);
         });
-
-        const handleMapZoom = () => updateReservoirFilters(map);
-
-        map.on('zoom', handleMapZoom);
 
         // Resize and fit bounds to ensure consistent loading behavior in all screen sizes
         map.resize();
@@ -285,11 +304,7 @@ const MainMap: React.FC<Props> = (props) => {
             }
         );
 
-        return () => {
-            map.off('moveend', debouncedHandleMapMove);
-            map.off('zoomend', debouncedHandleMapMove);
-            map.off('zoom', handleMapZoom);
-        };
+        return () => {};
     }, [map]);
 
     useEffect(() => {

--- a/dashboard-ui/src/features/Map/utils.ts
+++ b/dashboard-ui/src/features/Map/utils.ts
@@ -480,7 +480,6 @@ export const getReservoirLabelPaint = (
                 ]),
             ],
         ],
-
         'text-halo-color': '#fff',
         'text-halo-width': 2,
     };
@@ -524,6 +523,7 @@ export const getReservoirLabelFilter = (
                 'FlamingGorge',
                 'ElephantButte',
                 'NewMelones',
+                'HungryHorse',
             ],
         ],
     ];
@@ -863,7 +863,7 @@ export const getFeatures = <T extends Geometry, V extends GeoJsonProperties>(
 };
 
 const ZOOM_HIGH = 8;
-const ZOOM_MID = 6;
+const ZOOM_MID = 5;
 
 const getProperty = (
     boundingGeographyLevel: BoundingGeographyLevel
@@ -956,11 +956,23 @@ const allOf = (
     return undefined;
 };
 
+/**
+ * Determines which state of zoom the dashboard is in. At ZOOM_MID forced display of reservoir labels ends and
+ * capacity determined logic takes over. At ZOOM_HIGH, all reservoir icons and labels are displayed, regardless of
+ * capacity. Use greater than or equal to mirror step expression.
+ *
+ * @param {number} zoom
+ * @returns {("high" | "mid" | "low")}
+ */
 const getZoomBucket = (zoom: number) => {
-    return zoom > ZOOM_HIGH ? 'high' : zoom > ZOOM_MID ? 'mid' : 'low';
+    return zoom >= ZOOM_HIGH ? 'high' : zoom >= ZOOM_MID ? 'mid' : 'low';
 };
 
-export const updateReservoirFilters = (map: Map) => {
+export const updateReservoirFilters = (map: Map | null) => {
+    if (!map) {
+        return;
+    }
+
     const zoom = map.getZoom();
     const zoomBucket = getZoomBucket(zoom);
 


### PR DESCRIPTION
### **Description**
Show Hungry Horse in the initial view, ensure labels render at the same time as detailed icon, cleans up hook logic for applying/managing debounced map interactions, and applies debounce logic for map zoom filter event.

### **AC**
- [x] Hungry Horse reservoir is labelled on page load
- [x] Labels render when the more detailed teacup icon loads in