### PR TITLE
Capitalize Western, separate time series

### DIFF
--- a/dashboard-ui/src/features/Help/About.tsx
+++ b/dashboard-ui/src/features/Help/About.tsx
@@ -45,7 +45,7 @@ export const About: React.FC<Props> = (props) => {
                     The Western Water Data Dashboard displays reservoir storage
                     conditions and other water-related information to support
                     understanding and management of water resources in the
-                    western United States. The dashboard focuses on reservoirs
+                    Western United States. The dashboard focuses on reservoirs
                     of interest to the Bureau of Reclamation.
                 </Text>
                 <Text {...paragraph}>
@@ -56,8 +56,8 @@ export const About: React.FC<Props> = (props) => {
                 </Text>
                 <Text {...paragraph}>
                     The dashboard also provides detailed teacup diagrams and
-                    historical reservoir storage timeseries plots for individual
-                    reservoirs.
+                    historical reservoir storage time series plots for
+                    individual reservoirs.
                 </Text>
                 <Text {...paragraph}>
                     You can use the dashboard to create customized reports

--- a/dashboard-ui/src/features/Help/consts.tsx
+++ b/dashboard-ui/src/features/Help/consts.tsx
@@ -258,7 +258,7 @@ export const sections: GlossarySection[] = [
                                 The boundaries of Department of the Interior
                                 (DOI) Unified Regions. The dashboard only
                                 displays the boundaries of the DOI regions in
-                                the western U.S. (Columbia-Pacific Northwest,
+                                the Western U.S. (Columbia-Pacific Northwest,
                                 California-Great Basin, Missouri Basin, Upper
                                 Colorado Basin, Lower Colorado Basin, and
                                 Arkansas-Rio Grande-Texas Gulf). For more
@@ -304,7 +304,7 @@ export const sections: GlossarySection[] = [
                         content: (
                             <Text {...content}>
                                 The boundaries of U.S. states. Only the 17
-                                western states are displayed. For more
+                                Western states are displayed. For more
                                 information, see{' '}
                                 {getAnchor(
                                     'API',

--- a/dashboard-ui/src/features/MapTools/Legend/utils.tsx
+++ b/dashboard-ui/src/features/MapTools/Legend/utils.tsx
@@ -34,13 +34,13 @@ export const getTooltipContent = (
             );
             return '';
         case String(LayerId.RegionsReference):
-            return 'The boundaries of the Department of the Interior Unified Regions in the western U.S.';
+            return 'The boundaries of the Department of the Interior Unified Regions in the Western U.S.';
         case String(LayerId.ManagingRegionsReference):
             return 'The boundaries of the Department of the Interior Regions that are responsible for managing Bureau of Reclamation assets.';
         case String(LayerId.BasinsReference):
             return 'The boundaries of 2-digit Hydrologic Units.';
         case String(LayerId.StatesReference):
-            return 'The boundaries of the 17 western U.S. states.';
+            return 'The boundaries of the 17 Western U.S. states.';
         case String(LayerId.USDroughtMonitor):
             return 'The current drought intensity, ranging from D0 (abnormally dry) to D4 (exceptional drought).';
         case String(LayerId.NOAAPrecipSixToTen):


### PR DESCRIPTION
### **Description**
References to the Western US should be capitalized, separate timeseries -> time series.