### PR TITLE
Reduce teacup crawl

### DIFF
--- a/packages/teacup/teacup/__init__.py
+++ b/packages/teacup/teacup/__init__.py
@@ -13,7 +13,7 @@ from osgeo import ogr
 import os
 from time import sleep
 
-from teacup.env import BASE_URL, POSTGRES_URL
+from teacup.env import BASE_URL, OGR_BATCH_SIZE, POSTGRES_URL
 from teacup.lib import (
     create_feature,
     date_range,
@@ -127,7 +127,7 @@ def run_subprocess(csv_url: str):
         create_feature(pg_layer, row, "p90")
 
         count += 4  # 4 features created per row (raw, avg, p10, p90)
-        if count % 1000 == 0:
+        if count % OGR_BATCH_SIZE == 0:
             try:
                 pg_layer.CommitTransaction()
                 LOGGER.info(f"Committed {count} features to database...")
@@ -177,7 +177,7 @@ def load(start, end, url):
         return
 
     today = date.today()
-    start_date = dateparse(start).date() if start else today - timedelta(days=2)
+    start_date = dateparse(start).date() if start else today - timedelta(days=1)
     end_date = dateparse(end).date() if end else today
 
     for dt in date_range(start_date, end_date):

--- a/packages/teacup/teacup/env.py
+++ b/packages/teacup/teacup/env.py
@@ -20,4 +20,4 @@ POSTGRES_URL = str(
     f"PG:dbname={POSTGRES_DB} host={POSTGRES_HOST} port={POSTGRES_PORT} user={POSTGRES_USER} password={POSTGRES_PASSWORD}"  # noqa
 )
 
-OGR_BATCH_SIZE = os.getenv("OGR_BATCH_SIZE", 1000)
+OGR_BATCH_SIZE = int(os.getenv("OGR_BATCH_SIZE", 1000))

--- a/packages/teacup/teacup/env.py
+++ b/packages/teacup/teacup/env.py
@@ -19,3 +19,5 @@ POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", "password")
 POSTGRES_URL = str(
     f"PG:dbname={POSTGRES_DB} host={POSTGRES_HOST} port={POSTGRES_PORT} user={POSTGRES_USER} password={POSTGRES_PASSWORD}"  # noqa
 )
+
+OGR_BATCH_SIZE = os.getenv("OGR_BATCH_SIZE", 1000)


### PR DESCRIPTION
- Reduce `teacup load` default behavior to only crawl a single day. We are running this multiple times a day so no need to crawl more than one day by default.
- Allow setting teacup insert batch size via environment variable to tune speed of inserts