### PR TITLE
Overwrite teacup values on conflict

### DIFF
--- a/packages/teacup/teacup/__init__.py
+++ b/packages/teacup/teacup/__init__.py
@@ -118,13 +118,13 @@ def run_subprocess(csv_url: str):
             continue
 
         # Upsert data value
-        create_feature(pg_layer, row, "raw")
+        create_feature(pg_ds, row, "raw")
         # Upsert average value
-        create_feature(pg_layer, row, "avg")
+        create_feature(pg_ds, row, "avg")
         # Upsert 10th percentile value
-        create_feature(pg_layer, row, "p10")
+        create_feature(pg_ds, row, "p10")
         # Upsert 90th percentile value
-        create_feature(pg_layer, row, "p90")
+        create_feature(pg_ds, row, "p90")
 
         count += 4  # 4 features created per row (raw, avg, p10, p90)
         if count % OGR_BATCH_SIZE == 0:

--- a/packages/teacup/teacup/lib.py
+++ b/packages/teacup/teacup/lib.py
@@ -429,16 +429,10 @@ def create_feature(pg_ds, row, parameter: str):
             '{parameter}'
         )
         ON CONFLICT (id)
-        DO UPDATE SET
-            value = EXCLUDED.value,
-            data_date = EXCLUDED.data_date,
-            monitoring_location_id = EXCLUDED.monitoring_location_id,
-            parameter_id = EXCLUDED.parameter_id;
+        DO UPDATE SET value = EXCLUDED.value;
     """
 
     try:
         pg_ds.ExecuteSQL(sql)
     except RuntimeError as e:
         LOGGER.error(e)
-    finally:
-        feature = None  # Release feature

--- a/packages/teacup/teacup/lib.py
+++ b/packages/teacup/teacup/lib.py
@@ -387,7 +387,7 @@ def date_range(start_date: date, end_date: date) -> Iterator[date]:
         yield start_date + timedelta(n)
 
 
-def create_feature(pg_layer, row, parameter: str):
+def create_feature(pg_ds, row, parameter: str):
     """Create postgres feature from a CSV row"""
 
     match parameter:
@@ -411,16 +411,33 @@ def create_feature(pg_layer, row, parameter: str):
         )
         return
 
-    feature = ogr.Feature(pg_layer.GetLayerDefn())
     id = f"{row['SiteId']}.{row['DataDate']}.{parameter}"
-    feature.SetField("id", id)
-    feature.SetField("value", row[p_val])
-    feature.SetField("data_date", row["DataDate"])
-    feature.SetField("monitoring_location_id", row["SiteId"])
-    feature.SetField("parameter_id", parameter)
+
+    sql = f"""
+        INSERT INTO teacup (
+            id,
+            value,
+            data_date,
+            monitoring_location_id,
+            parameter_id
+        )
+        VALUES (
+            '{id}',
+            {row[p_val]},
+            '{row["DataDate"]}',
+            '{row["SiteId"]}',
+            '{parameter}'
+        )
+        ON CONFLICT (id)
+        DO UPDATE SET
+            value = EXCLUDED.value,
+            data_date = EXCLUDED.data_date,
+            monitoring_location_id = EXCLUDED.monitoring_location_id,
+            parameter_id = EXCLUDED.parameter_id;
+    """
 
     try:
-        pg_layer.CreateFeature(feature)
+        pg_ds.ExecuteSQL(sql)
     except RuntimeError as e:
         LOGGER.error(e)
     finally:


### PR DESCRIPTION
Switch teacup data crawl to use inline SQL which allows us to replace the value on conflicts