### PR TITLE
chore(dashboard): ensure help modal content is always present in the dom

### DIFF
--- a/dashboard-ui/src/features/Help/index.tsx
+++ b/dashboard-ui/src/features/Help/index.tsx
@@ -92,11 +92,13 @@ const Help: React.FC = () => {
                 classNames={{ header: styles.modalHeader }}
                 opened={opened}
                 onClose={handleClose}
+                keepMounted
             >
                 <Tabs
                     value={helpTab}
                     className={`${styles.modalBody} ${styles.tabs}`}
                     onChange={(tab) => setHelpTab(tab as HelpTab)}
+                    keepMounted
                 >
                     <Tabs.List className={styles.tabsList} grow>
                         <Tabs.Tab value={HelpTab.About}>


### PR DESCRIPTION
### **Description**
Keeps the help modal and all tabs mounted in the DOM so that this content is crawlable by site indexers.

### **To Test**
1. Open the dev inspector
2. Select the help modal element or find its portal in the DOM tree
3. Close the help modal

Result:
Content is still present even when the help modal is not visible to the user