### PR TITLE
fix(dashboard): set targets, remove email link

### DIFF
--- a/dashboard-ui/src/features/Help/Contact.tsx
+++ b/dashboard-ui/src/features/Help/Contact.tsx
@@ -50,6 +50,7 @@ export const Contact: React.FC = () => {
                                     title={contact.link.text}
                                     size="sm"
                                     c="blue.8"
+                                    target="_blank"
                                     lineClamp={1}
                                 >
                                     {contact.link.text}

--- a/dashboard-ui/src/features/Help/consts.tsx
+++ b/dashboard-ui/src/features/Help/consts.tsx
@@ -973,17 +973,22 @@ export const contacts: Contact[] = [
                 This application follows{' '}
                 <Anchor
                     href="https://internetofwater.org/internet-of-water-principles/"
+                    target="_blank"
                     c="blue.8"
                 >
                     Internet of Water Principles
                 </Anchor>{' '}
                 for interoperable water data. Application design and development
                 provided by the{' '}
-                <Anchor href="https://cgsearth.org/" c="blue.8">
+                <Anchor href="https://cgsearth.org/" target="_blank" c="blue.8">
                     Center for Geospatial Solutions
                 </Anchor>{' '}
                 at the{' '}
-                <Anchor href="https://www.lincolninst.edu/" c="blue.8">
+                <Anchor
+                    href="https://www.lincolninst.edu/"
+                    target="_blank"
+                    c="blue.8"
+                >
                     Lincoln Institute of Land Policy
                 </Anchor>
                 .
@@ -997,11 +1002,7 @@ export const contacts: Contact[] = [
         body: (
             <Text {...content}>
                 For questions or feedback on the Western Water Data Dashboard,
-                please contact the Bureau of Reclamation at{' '}
-                <Anchor {...content} href="data@usbr.gov" c="blue.8">
-                    data@usbr.gov
-                </Anchor>
-                .
+                please contact the Bureau of Reclamation at data@usbr.gov.
             </Text>
         ),
         link: {


### PR DESCRIPTION
### **Description**
Ensures users arent taken off the dashboard by links in the contact page. Remove anchor link for email before mailto link.